### PR TITLE
Fix resolve parameter in compiler pass

### DIFF
--- a/DependencyInjection/Compiler/AddSitemapListenersPass.php
+++ b/DependencyInjection/Compiler/AddSitemapListenersPass.php
@@ -40,6 +40,10 @@ class AddSitemapListenersPass implements CompilerPassInterface
         foreach ($container->findTaggedServiceIds('presta.sitemap.listener') as $id => $tags) {
             $class = $container->getDefinition($id)->getClass();
 
+            // Resolve parameters
+            $parametersBag = $container->getParameterBag();
+            $class = $parametersBag->resolveValue($class);
+
             $refClass = new \ReflectionClass($class);
             $interface = 'Presta\SitemapBundle\Service\SitemapListenerInterface';
             if (!$refClass->implementsInterface($interface)) {


### PR DESCRIPTION
I has a problem with set listener class as parameter:

``` xml
<!-- Sitemap listener -->
<service id="blog.sitemap.listener" class="%blog.sitemap.listener.class%">
    <tag name="presta.sitemap.listener" />
    <argument type="service" id="service_container" />
</service>
```
