### PR TITLE
Fix for building sitemap in test environment

### DIFF
--- a/DependencyInjection/Compiler/AddSitemapListenersPass.php
+++ b/DependencyInjection/Compiler/AddSitemapListenersPass.php
@@ -32,10 +32,14 @@ class AddSitemapListenersPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         if (!$container->hasDefinition('event_dispatcher')) {
-            return;
+            if (!$container->hasAlias('event_dispatcher')) {
+                return;
+            } else {
+                $definition = $container->getDefinition($container->getAlias('event_dispatcher'));
+            }
+        } else {
+            $definition = $container->getDefinition('event_dispatcher');
         }
-
-        $definition = $container->getDefinition('event_dispatcher');
 
         foreach ($container->findTaggedServiceIds('presta.sitemap.listener') as $id => $tags) {
             $class = $container->getDefinition($id)->getClass();


### PR DESCRIPTION
Hey guys.

Sinse `event_dispatcher` is just an alias of `debug.event_dispatcher` definition in test environment this code

``` php
$definition = $container->getDefinition('event_dispatcher');
```

doesn't work. So i added another one check for alias existence.
