### PR TITLE
Fix AddSitemapListenersPass (possible fix for #47)

### DIFF
--- a/DependencyInjection/Compiler/AddSitemapListenersPass.php
+++ b/DependencyInjection/Compiler/AddSitemapListenersPass.php
@@ -31,11 +31,11 @@ class AddSitemapListenersPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasDefinition('event_dispatcher')) {
+        if (!$container->hasDefinition('event_dispatcher') && !$container->hasAlias('event_dispatcher')) {
             return;
         }
 
-        $definition = $container->getDefinition('event_dispatcher');
+        $definition = $container->findDefinition('event_dispatcher');
 
         foreach ($container->findTaggedServiceIds('presta.sitemap.listener') as $id => $tags) {
             $class = $container->getDefinition($id)->getClass();


### PR DESCRIPTION
Don't know if it really fix #47 but I have problem with current behavior on Symfony 2.4.2-dev.
