### PR TITLE
Added filter_var instead of direct checking

### DIFF
--- a/EventListener/RouteAnnotationEventListener.php
+++ b/EventListener/RouteAnnotationEventListener.php
@@ -103,7 +103,7 @@ class RouteAnnotationEventListener implements SitemapListenerInterface
             return null;
         }
 
-        if ($option !== true && !is_array($option)) {
+        if (!is_array($option) && filter_var($option, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) === null) {
             throw new \InvalidArgumentException('the sitemap option must be "true" or an array of parameters');
         }
 


### PR DESCRIPTION
I don't really like annotation limitation for routes marked for sitemap. Now you can use XML too:

<route id="route" pattern="/">
        <default key="_controller">AcmeDemoBundle:Default:home</default>
        <option key="sitemap">true</option>
</route>