### PR TITLE
Move sitemap files from tmp dir instead of copy

### DIFF
--- a/Service/Dumper.php
+++ b/Service/Dumper.php
@@ -202,7 +202,13 @@ class Dumper extends AbstractGenerator
         $this->deleteExistingSitemaps($targetDir);
 
         // no need to delete the root file as it always exists, it will be overwritten
-        $this->filesystem->mirror($this->tmpFolder, $targetDir, null, array('override' => true));
+        $iterator = new \DirectoryIterator($this->tmpFolder);
+        foreach ($iterator as $file) {
+            if (!$file->isDot()) {
+                $this->filesystem->rename($file->getPathname(), $targetDir.'/'.$file->getFilename(), true);
+            }
+        }
+
         $this->cleanup();
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no for sf >= 2.3, yes for 2.1. and 2.2 |
| Deprecations? | no |
| Tests pass? | yes for sf >= 2.3, no for Symfony versions 2.1 and 2.2 - we can replace `filesysten->rename()` with php function `rename()` to avoid BC break) |
| Fixed tickets | - |
| License | MIT |

The `mirror` method is copying all sitemap files from tmp folder. The problem with this is that read/write operations are not atomic (and `copy` method in `Filesystem` is using no locks), so the xml files can be corrupted if two processes are trying to read/write (copy) their own versions of sitemaps to the public directory.
