### PR TITLE
feat(base_url): fallback to symonfy router context instead of hardcoded localhost

### DIFF
--- a/Command/DumpSitemapsCommand.php
+++ b/Command/DumpSitemapsCommand.php
@@ -80,6 +80,12 @@ class DumpSitemapsCommand extends ContainerAwareCommand
         /* @var $dumper \Presta\SitemapBundle\Service\Dumper */
 
         $baseUrl = $input->getOption('base-url') ?: $container->getParameter('presta_sitemap.dumper_base_url');
+
+        if (null === $baseUrl) {
+            $context = $container->get('router')->getContext();
+            $baseUrl = sprintf('%s://%s/', $context->getScheme(), $context->getHost());
+        }
+
         $baseUrl = rtrim($baseUrl, '/') . '/';
         if (!parse_url($baseUrl, PHP_URL_HOST)) { //sanity check
             throw new \InvalidArgumentException("Invalid base url. Use fully qualified base url, e.g. http://acme.com/", self::ERR_INVALID_HOST);

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -39,7 +39,7 @@ class Configuration implements ConfigurationInterface
                         ->info('Sets sitemap filename prefix defaults to "sitemap" -> sitemap.xml (for index); sitemap.<section>.xml(.gz) (for sitemaps)')
                     ->end()
                     ->scalarNode('dumper_base_url')
-                        ->defaultValue('http://localhost/')
+                        ->defaultValue(null)
                         ->info('Deprecated: please use host option in command. Used for dumper command. Default host to use if host argument is missing')
                     ->end()
                     ->scalarNode('route_annotation_listener')->defaultTrue()->end()

--- a/Tests/Command/DumpSitemapsCommandTest.php
+++ b/Tests/Command/DumpSitemapsCommandTest.php
@@ -81,6 +81,18 @@ class DumpSitemapsCommandTest extends WebTestCase
         $this->assertXmlFileEqualsXmlFile($this->fixturesDir . '/sitemap.video.xml', $this->webDir . '/sitemap.video.xml');
     }
 
+    public function testSitemapDumpWithRouterContextUrl()
+    {
+        //set routing context
+        $context = $this->container->get('router')->getContext();
+        $context->setHost('sitemap.php54.local');
+        $context->setScheme('http');
+
+        $res = $this->executeDumpWithOptions(array('target' => $this->webDir));
+        $this->assertEquals(0, $res, 'Command exited with error');
+        $this->assertXmlFileEqualsXmlFile($this->fixturesDir . '/sitemap.video.xml', $this->webDir . '/sitemap.video.xml');
+    }
+
     public function testSitemapDumpWithGzip()
     {
         $res = $this->executeDumpWithOptions(array('target' => $this->webDir, '--base-url' => 'http://sitemap.php54.local/', '--gzip' => true));


### PR DESCRIPTION
Since Symfony suggests this (http://symfony.com/doc/current/cookbook/console/sending_emails.html) to use base paths outside request context, i would recommend to use the router context for fallback to localhost.

You would be able to use your parameters.yml config without specifying it in config or in the command. The change is fully BC, since router context falls back to http and localhost anyway.

```
# app/config/parameters.yml
parameters:
    router.request_context.host: mysite.ch
    router.request_context.scheme: https
```

Would do the job to start the dump without any config in presta or specifying urls in the command.

Chers

