### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,8 @@ Sandbox is also deployed for a live demonstration :
 
 1. Installation
 
-    ```js
-        //composer.json
-        "require": {
-            //...
-            "presta/sitemap-bundle": "dev-master"
-        }
+    ```sh
+    composer require presta/sitemap-bundle
     ```
 
     ```php


### PR DESCRIPTION
Updated installation instructions via composer to use the `composer require` command without specifying a version.
This is the new recommended way of providing this information and it leads to composer picking the proper version constraint (i.e ~1.2), updating the `composer.json` and running install, all in one command.