### PR TITLE
Prevent sitemap files showing up in search results

### DIFF
--- a/Controller/SitemapController.php
+++ b/Controller/SitemapController.php
@@ -38,6 +38,7 @@ class SitemapController extends Controller
         $response = Response::create($sitemapindex->toXml());
         $response->setPublic();
         $response->setClientTtl($this->getTtl());
+        $response->headers->set('X-Robots-Tag', 'noindex');
 
         return $response;
     }
@@ -59,6 +60,7 @@ class SitemapController extends Controller
         $response = Response::create($section->toXml());
         $response->setPublic();
         $response->setClientTtl($this->getTtl());
+        $response->headers->set('X-Robots-Tag', 'noindex');
 
         return $response;
     }


### PR DESCRIPTION
Prevent sitemap xml files showing up in search results by telling googlebot to not index them with `X-Robots-Tag` to `noindex`.