### PR TITLE
Add the ability to configure the number of items by sitemap

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -10,6 +10,7 @@
 
 namespace Presta\SitemapBundle\DependencyInjection;
 
+use Presta\SitemapBundle\Sitemap\XmlConstraint;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -31,18 +32,24 @@ class Configuration implements ConfigurationInterface
         $rootNode = $treeBuilder->root('presta_sitemap');
 
         $rootNode->children()
-                    ->scalarNode('timetolive')
-                        ->defaultValue('3600')
-                    ->end()
-                    ->scalarNode('sitemap_file_prefix')
-                        ->defaultValue(self::DEFAULT_FILENAME)
-                        ->info('Sets sitemap filename prefix defaults to "sitemap" -> sitemap.xml (for index); sitemap.<section>.xml(.gz) (for sitemaps)')
-                    ->end()
-                    ->scalarNode('dumper_base_url')
-                        ->defaultValue('http://localhost/')
-                        ->info('Deprecated: please use host option in command. Used for dumper command. Default host to use if host argument is missing')
-                    ->end()
-                    ->scalarNode('route_annotation_listener')->defaultTrue()->end()
+            ->scalarNode('timetolive')
+                ->defaultValue('3600')
+            ->end()
+            ->scalarNode('sitemap_file_prefix')
+                ->defaultValue(self::DEFAULT_FILENAME)
+                ->info('Sets sitemap filename prefix defaults to "sitemap" -> sitemap.xml (for index); sitemap.<section>.xml(.gz) (for sitemaps)')
+            ->end()
+            ->scalarNode('dumper_base_url')
+                ->defaultValue('http://localhost/')
+                ->info('Deprecated: please use host option in command. Used for dumper command. Default host to use if host argument is missing')
+            ->end()
+            ->scalarNode('items_by_set')
+                // Add one to the limit items value because it's an
+                // index value (not a quantity)
+                ->defaultValue(XmlConstraint::LIMIT_ITEMS + 1)
+                ->info('The maximum number of items allowed in single sitemap.')
+            ->end()
+            ->scalarNode('route_annotation_listener')->defaultTrue()->end()
         ;
 
         return $treeBuilder;

--- a/DependencyInjection/PrestaSitemapExtension.php
+++ b/DependencyInjection/PrestaSitemapExtension.php
@@ -30,13 +30,14 @@ class PrestaSitemapExtension extends Extension
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
-        
+
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.xml');
-        
+
         $container->setParameter($this->getAlias().'.timetolive', $config['timetolive']);
         $container->setParameter($this->getAlias().'.sitemap_file_prefix', $config['sitemap_file_prefix']);
         $container->setParameter($this->getAlias().'.dumper_base_url', $config['dumper_base_url']);
+        $container->setParameter($this->getAlias().'.items_by_set', $config['items_by_set']);
 
         if (true === $config['route_annotation_listener']) {
             $loader->load('route_annotation_listener.xml');

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -15,12 +15,14 @@
             <argument id="router" type="service" />
             <argument id="liip_doctrine_cache.ns.presta_sitemap" type="service" on-invalid="ignore"/>
             <argument>%presta_sitemap.timetolive%</argument>
+            <argument>%presta_sitemap.items_by_set%</argument>
         </service>
 
         <service id="presta_sitemap.dumper" class="%presta_sitemap.dumper.class%">
             <argument id="event_dispatcher" type="service" />
             <argument id="filesystem" type="service" />
             <argument>%presta_sitemap.sitemap_file_prefix%</argument>
+            <argument>%presta_sitemap.items_by_set%</argument>
         </service>
     </services>
 

--- a/Resources/doc/2-Configuration.md
+++ b/Resources/doc/2-Configuration.md
@@ -26,7 +26,7 @@ presta_sitemap:
 
 ## Annotation
 
-The listener that provides annotation support is enabled by default. To disable it, add the following configuration to 
+The listener that provides annotation support is enabled by default. To disable it, add the following configuration to
 your application.
 
 ```yaml
@@ -34,13 +34,24 @@ presta_sitemap:
    route_annotation_listener: false
 ```
 
-## Cache [optional] 
+## Items by set [optional]
+
+You can change the default maximum number of items generated for each sitemap
+with the following configuration. It cannot break the maximum limit of
+50,000 items and maximum size of 1,000,000 bytes. The default value is 50,000.
+
+```yaml
+presta_sitemap:
+    items_by_set: 50000
+```
+
+## Cache [optional]
 
 Each sitemaps can be stored in your cache system :
 
-PrestaSitemapBundle uses LiipDoctrineCacheBundle to store Cache. 
+PrestaSitemapBundle uses LiipDoctrineCacheBundle to store Cache.
 This bundle provides an abstract access to any Doctrine Common Cache classes.
-You need to install LiipDoctrineCacheBundle and specify what kind of cache 
+You need to install LiipDoctrineCacheBundle and specify what kind of cache
 system to use with PrestaSitemap.
 
  * Follow the instruction to install [LiipDoctrineCacheBundle](http://packagist.org/packages/liip/doctrine-cache-bundle).

--- a/Service/Dumper.php
+++ b/Service/Dumper.php
@@ -52,13 +52,15 @@ class Dumper extends AbstractGenerator
      * @param EventDispatcherInterface $dispatcher Symfony's EventDispatcher
      * @param Filesystem $filesystem Symfony's Filesystem
      * @param $sitemapFilePrefix
+     * @param int $itemsBySet
      */
     public function __construct(
         EventDispatcherInterface $dispatcher,
         Filesystem $filesystem,
-        $sitemapFilePrefix = Configuration::DEFAULT_FILENAME
+        $sitemapFilePrefix = Configuration::DEFAULT_FILENAME,
+        $itemsBySet = null
     ) {
-        parent::__construct($dispatcher);
+        parent::__construct($dispatcher, $itemsBySet);
         $this->filesystem = $filesystem;
         $this->sitemapFilePrefix = $sitemapFilePrefix;
     }

--- a/Service/Generator.php
+++ b/Service/Generator.php
@@ -30,13 +30,14 @@ class Generator extends AbstractGenerator
 
     /**
      * @param EventDispatcherInterface $dispatcher
+     * @param int $itemsBySet
      * @param RouterInterface $router
      * @param Cache|null $cache
      * @param integer|null $cacheTtl
      */
-    public function __construct(EventDispatcherInterface $dispatcher, RouterInterface $router, Cache $cache = null, $cacheTtl = null)
+    public function __construct(EventDispatcherInterface $dispatcher, RouterInterface $router, Cache $cache = null, $cacheTtl = null, $itemsBySet = null)
     {
-        parent::__construct($dispatcher);
+        parent::__construct($dispatcher, $itemsBySet);
         $this->router = $router;
         $this->cache = $cache;
         $this->cacheTtl = $cacheTtl;

--- a/Sitemap/XmlConstraint.php
+++ b/Sitemap/XmlConstraint.php
@@ -16,7 +16,7 @@ namespace Presta\SitemapBundle\Sitemap;
  *
  * @author depely
  */
-abstract class XmlConstraint
+abstract class XmlConstraint implements \Countable
 {
     const LIMIT_ITEMS = 49999;
     const LIMIT_BYTES = 10000000; // 10,485,760 bytes - 485,760
@@ -32,6 +32,14 @@ abstract class XmlConstraint
     public function isFull()
     {
         return $this->limitItemsReached || $this->limitBytesReached;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function count()
+    {
+        return $this->countItems;
     }
 
     /**

--- a/Tests/Service/GeneratorTest.php
+++ b/Tests/Service/GeneratorTest.php
@@ -27,7 +27,7 @@ class GeneratorTest extends WebTestCase
         self::createClient();
         $container  = static::$kernel->getContainer();
 
-        $this->generator = new Generator($container->get('event_dispatcher'), $container->get('router'));
+        $this->generator = new Generator($container->get('event_dispatcher'), $container->get('router'), null, null, 1);
     }
 
     public function testGenerate()
@@ -59,5 +59,19 @@ class GeneratorTest extends WebTestCase
         $urlset = $this->generator->getUrlset('default');
 
         $this->assertInstanceOf('Presta\\SitemapBundle\\Sitemap\\Urlset', $urlset);
+    }
+
+    public function testItemsBySet()
+    {
+        $url = new Sitemap\Url\UrlConcrete('http://acme.com/');
+
+        $this->generator->addUrl($url, 'default');
+        $this->generator->addUrl($url, 'default');
+
+        $fullUrlset  = $this->generator->getUrlset('default_0');
+        $emptyUrlset = $this->generator->getUrlset('default_1');
+
+        $this->assertEquals(count($fullUrlset), 1);
+        $this->assertEquals(count($emptyUrlset), 0);
     }
 }


### PR DESCRIPTION
My need is to be able to configure sitemaps to only have 25,000 entries by file. There is currently a limit of 50,000 entries by sitemap.

This limit is hardcoded as a constraint. I decided to keep it as is, and add a configuration beside to let the developper chose the value. So the limit is still here (and not breakable), but there is a way to set a lower maximum. I added the optional configuration key `items_by_set`, which has a default value to 50,000.

These changes should be backward compatible. All unit tests (including a new one) should pass.