### PR TITLE
Fix deprecated routing config options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ php:
     - 5.5
 
 env:
-    - SYMFONY_VERSION=2.1.*
     - SYMFONY_VERSION=2.2.*
     - SYMFONY_VERSION=2.3.*
     - SYMFONY_VERSION=2.4.*
     - SYMFONY_VERSION=2.5.*
+    - SYMFONY_VERSION=2.6.*
     - SYMFONY_VERSION=dev-master
 
 before_script:

--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,12 +1,12 @@
 PrestaSitemapBundle_index:
-    pattern:  /%presta_sitemap.sitemap_file_prefix%.{_format}
+    path:  /%presta_sitemap.sitemap_file_prefix%.{_format}
     defaults: { _controller: PrestaSitemapBundle:Sitemap:index }
     requirements:
         _format: xml
         
         
 PrestaSitemapBundle_section:
-    pattern:  /%presta_sitemap.sitemap_file_prefix%.{name}.{_format}
+    path:  /%presta_sitemap.sitemap_file_prefix%.{name}.{_format}
     defaults: { _controller: PrestaSitemapBundle:Sitemap:section }
     requirements:
         _format: xml

--- a/Tests/app/routing.yml
+++ b/Tests/app/routing.yml
@@ -3,5 +3,5 @@ PrestaSitemapBundle:
     prefix:   /
 
 PrestaDemoBundle_homepage:
-    pattern: /
+    path: /
     defaults: { _controller: PrestaSitemapBundle:Sitemap:index }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require": {
         "php": ">=5.3.0",
-        "symfony/symfony": ">=2.1.0"
+        "symfony/symfony": ">=2.2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*@stable"


### PR DESCRIPTION
Fixes deprecation messages for Symfony 2.7.

This bumps the minimum symfony version to 2.2, as pattern was replaced by path since 2.2