### PR TITLE
Added .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/.gitattributes    export-ignore
+/.gitignore        export-ignore
+/.travis.yml       export-ignore
+/.phpunit.xml.dist export-ignore
+/.Makefile         export-ignore
+/Tests             export-ignore
+


### PR DESCRIPTION
This fix excludes several files that are not needed when this bundle is installed as a dependency in a Symfony project, see [this article](http://blog.madewithlove.be/post/gitattributes/) for more info.