### PR TITLE
Improve Travis & Composer config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,29 +4,55 @@ php:
     - 5.3
     - 5.4
     - 5.5
-
-env:
-    - SYMFONY_VERSION=2.1.*
-    - SYMFONY_VERSION=2.2.*
-    - SYMFONY_VERSION=2.3.*
-    - SYMFONY_VERSION=2.4.*
-    - SYMFONY_VERSION=2.5.*
-    - SYMFONY_VERSION=dev-master
-
-before_script:
-    - pear install pear/PHP_CodeSniffer
-    - phpenv rehash
-    - composer selfupdate
-    - composer require symfony/symfony:${SYMFONY_VERSION}
-
-script:
-    - phpunit --coverage-text
-    - phpcs --ignore=/vendor/*,/Tests/app/* --extensions=php --encoding=utf-8 --standard=PSR2 -np .
+    - 5.6
+    - 7.0
+    - hhvm
 
 matrix:
-  allow_failures:
-    - env: SYMFONY_VERSION=dev-master
+    include:
+        - php: 5.6
+          env: SYMFONY_VERSION=2.1.*
+        - php: 5.6
+          env: SYMFONY_VERSION=2.2.*
+        - php: 5.6
+          env: SYMFONY_VERSION=2.3.*
+        - php: 5.6
+          env: SYMFONY_VERSION=2.4.*
+        - php: 5.6
+          env: SYMFONY_VERSION=2.5.*
+        - php: 5.6
+          env: SYMFONY_VERSION=2.6.*
+        - php: 5.6
+          env: SYMFONY_VERSION=2.8.*@dev SYMFONY_DEPRECATIONS_HELPER=strict
+        - php: 5.6
+          env: SYMFONY_VERSION=3.0.*@dev SYMFONY_DEPRECATIONS_HELPER=strict
+        - php: 5.6
+          env: PHPCS=yes
+    allow_failures:
+        - env: SYMFONY_VERSION=3.0.*@dev
+
+env:
+    global:
+        - SYMFONY_DEPRECATIONS_HELPER=weak
+
+sudo: false
+
+cache:
+    directories:
+        - $HOME/.composer/cache
+
+before_install:
+    - if [ "$PHPCS" = "yes" ]; then pear install pear/PHP_CodeSniffer; fi
+    - if [ "$PHPCS" = "yes" ]; then phpenv rehash; fi
+    - if [ "$PHPCS" != "yes"]; then composer selfupdate; fi
+    - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/symfony:${SYMFONY_VERSION}; fi
+
+install: if [ "$PHPCS" != "yes" ]; then composer update --prefer-dist; fi
+
+script:
+    - if [ "$PHPCS" != "yes" ]; then phpunit --coverage-text; fi
+    - if [ "$PHPCS" = "yes" ]; then phpcs --ignore=/vendor/*,/Tests/app/* --extensions=php --encoding=utf-8 --standard=PSR2 -np .; fi
 
 notifications:
-  email:
-    - aflaus@prestaconcept.net
+    email:
+        - aflaus@prestaconcept.net

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ php:
 matrix:
     include:
         - php: 5.6
-          env: SYMFONY_VERSION=2.1.*
-        - php: 5.6
           env: SYMFONY_VERSION=2.2.*
         - php: 5.6
           env: SYMFONY_VERSION=2.3.*

--- a/EventListener/RouteAnnotationEventListener.php
+++ b/EventListener/RouteAnnotationEventListener.php
@@ -15,6 +15,7 @@ use Presta\SitemapBundle\Event\SitemapPopulateEvent;
 use Presta\SitemapBundle\Service\SitemapListenerInterface;
 use Presta\SitemapBundle\Sitemap\Url\UrlConcrete;
 use Symfony\Component\Routing\Exception\MissingMandatoryParametersException;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -171,7 +172,7 @@ class RouteAnnotationEventListener implements SitemapListenerInterface
     {
         // does the route need parameters? if so, we can't add it
         try {
-            return $this->router->generate($name, array(), true);
+            return $this->router->generate($name, array(), UrlGeneratorInterface::ABSOLUTE_URL);
         } catch (MissingMandatoryParametersException $e) {
             throw new \InvalidArgumentException(
                 sprintf(

--- a/README.md
+++ b/README.md
@@ -78,9 +78,12 @@ Sandbox is also deployed for a live demonstration :
     For complexe routes, create a [Closure][3] or a [Service][5] dedicated to your sitemap then add your urls :
 
     ```php
+    use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+    // ...
+
         function(SitemapPopulateEvent $event) use ($router){
             //get absolute homepage url
-            $url = $router->generate('homepage', array(), true);
+            $url = $router->generate('homepage', array(), UrlGeneratorInterface::ABSOLUTE_URL);
 
             //add homepage url to the urlset named default
             $event->getGenerator()->addUrl(

--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,12 +1,12 @@
 PrestaSitemapBundle_index:
-    pattern:  /%presta_sitemap.sitemap_file_prefix%.{_format}
+    path:     /%presta_sitemap.sitemap_file_prefix%.{_format}
     defaults: { _controller: PrestaSitemapBundle:Sitemap:index }
     requirements:
         _format: xml
         
         
 PrestaSitemapBundle_section:
-    pattern:  /%presta_sitemap.sitemap_file_prefix%.{name}.{_format}
+    path:     /%presta_sitemap.sitemap_file_prefix%.{name}.{_format}
     defaults: { _controller: PrestaSitemapBundle:Sitemap:section }
     requirements:
         _format: xml

--- a/Resources/doc/3-Usage-Quick_and_dirty.md
+++ b/Resources/doc/3-Usage-Quick_and_dirty.md
@@ -12,6 +12,7 @@ For example in your AcmeDemoBundle :
 namespace Acme\DemoBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 use Presta\SitemapBundle\Event\SitemapPopulateEvent;
 use Presta\SitemapBundle\Sitemap\Url\UrlConcrete;
@@ -28,7 +29,7 @@ class AcmeDemoBundle extends Bundle
             SitemapPopulateEvent::ON_SITEMAP_POPULATE,
             function(SitemapPopulateEvent $event) use ($router){
                 //get absolute homepage url
-                $url = $router->generate('homepage', array(), true);
+                $url = $router->generate('homepage', array(), UrlGeneratorInterface::ABSOLUTE_URL);
 
                 //add homepage url to the urlset named default
                 $event->getGenerator()->addUrl(

--- a/Resources/doc/5-Usage-Event_Listener.md
+++ b/Resources/doc/5-Usage-Event_Listener.md
@@ -37,6 +37,7 @@ Sitemap listener example `Acme/DemoBundle/EventListener/SitemapListener.php`
 namespace Acme\DemoBundle\EventListener;
 
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 use Presta\SitemapBundle\Service\SitemapListenerInterface;
 use Presta\SitemapBundle\Event\SitemapPopulateEvent;
@@ -56,7 +57,7 @@ class SitemapListener implements SitemapListenerInterface
         $section = $event->getSection();
         if (is_null($section) || $section == 'default') {
             //get absolute homepage url
-            $url = $this->router->generate('homepage', array(), true);
+            $url = $this->router->generate('homepage', array(), UrlGeneratorInterface::ABSOLUTE_URL);
 
             //add homepage url to the urlset named default
             $event->getGenerator()->addUrl(

--- a/Service/Generator.php
+++ b/Service/Generator.php
@@ -13,6 +13,7 @@ namespace Presta\SitemapBundle\Service;
 use Doctrine\Common\Cache\Cache;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Presta\SitemapBundle\Sitemap;
 
 /**
@@ -100,7 +101,7 @@ class Generator extends AbstractGenerator
     protected function newUrlset($name, \DateTime $lastmod = null)
     {
         return new Sitemap\Urlset(
-            $this->router->generate('PrestaSitemapBundle_section', array('name' => $name, '_format' => 'xml'), true),
+            $this->router->generate('PrestaSitemapBundle_section', array('name' => $name, '_format' => 'xml'), UrlGeneratorInterface::ABSOLUTE_URL),
             $lastmod
         );
     }

--- a/Tests/Command/DumpSitemapsCommandTest.php
+++ b/Tests/Command/DumpSitemapsCommandTest.php
@@ -20,6 +20,7 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * @author Alex Vasilenko
@@ -48,7 +49,7 @@ class DumpSitemapsCommandTest extends WebTestCase
             ->addListener(
                 SitemapPopulateEvent::ON_SITEMAP_POPULATE,
                 function (SitemapPopulateEvent $event) use ($router) {
-                    $base_url   = $router->generate('PrestaDemoBundle_homepage', array(), true);
+                    $base_url   = $router->generate('PrestaDemoBundle_homepage', array(), UrlGeneratorInterface::ABSOLUTE_URL);
                     $urlVideo = new GoogleVideoUrlDecorator(
                         new UrlConcrete($base_url . 'page_video1/'),
                         $base_url . 'page_video1/thumbnail_loc?a=b&b=c',

--- a/Tests/app/routing.yml
+++ b/Tests/app/routing.yml
@@ -3,5 +3,5 @@ PrestaSitemapBundle:
     prefix:   /
 
 PrestaDemoBundle_homepage:
-    pattern: /
+    path:     /
     defaults: { _controller: PrestaSitemapBundle:Sitemap:index }

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "symfony/symfony": ">=2.1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*@stable"
+        "phpunit/phpunit": "3.7.*@stable",
+        "symfony/phpunit-bridge": "~2.7|~3.0"
     },
     "suggest": {
         "liip/doctrine-cache-bundle" : "Allows to store sitemaps in cache"

--- a/composer.json
+++ b/composer.json
@@ -31,11 +31,10 @@
         "liip/doctrine-cache-bundle" : "Allows to store sitemaps in cache"
     },
     "autoload": {
-        "psr-0": {
+        "psr-4": {
             "Presta\\SitemapBundle\\": ""
         }
     },
-    "target-dir" : "Presta/SitemapBundle",
     "extra": {
         "branch-alias": {
             "dev-master": "1.3.x-dev"

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
         "symfony/symfony": "~2.1|~3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*@stable",
         "symfony/phpunit-bridge": "~2.7|~3.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require": {
         "php": ">=5.3.0",
-        "symfony/symfony": "~2.1|~3.0"
+        "symfony/symfony": "~2.2|~3.0"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "~2.7|~3.0"

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require": {
         "php": ">=5.3.0",
-        "symfony/symfony": ">=2.1.0"
+        "symfony/symfony": "~2.1|~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*@stable",


### PR DESCRIPTION
**Travis**

 * Use the faster docker based Travis environment + the caching feature it provides
 * Test against all supported Symfony and PHP versions
 * Instead of testing all Symfony versions against all PHP versions, test all PHP versions against one Symfony version (latest stable) and test all Symfony versions against one PHP version (latest stable).
 * Instead of running phpcs every job, have a special job for phpcs (even better would be to use StyleCI instead of Travis)

**Composer**

 * Do not claim Symfony >=2.1.0 support as you don't know if this bundle supports Symfony 10.
 * Use PSR-4 instead of the deprecated target-path and PSR-0 autoloading logic