### PR TITLE
Update branch-alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.3.x-dev"
+            "dev-master": "1.5.x-dev"
         }
     }
 }


### PR DESCRIPTION
The branch-alias should be always the next one.
Being the current stable `1.4`, it should be `1.5` now