### PR TITLE
Preserve Previous Exception in getRouteUri

### DIFF
--- a/EventListener/RouteAnnotationEventListener.php
+++ b/EventListener/RouteAnnotationEventListener.php
@@ -178,7 +178,9 @@ class RouteAnnotationEventListener implements SitemapListenerInterface
                 sprintf(
                     'The route "%s" cannot have the sitemap option because it requires parameters',
                     $name
-                )
+                ),
+                0,
+                $e
             );
         }
     }


### PR DESCRIPTION
This usually helps a lot with debugging by preserving the stack trace. There is no reason to break the stack trace.