### PR TITLE
Change default URL priority to the 0.5

### DIFF
--- a/Sitemap/Url/UrlConcrete.php
+++ b/Sitemap/Url/UrlConcrete.php
@@ -42,7 +42,7 @@ class UrlConcrete implements Url
      * @param string $changefreq
      * @param float $priority
      */
-    public function __construct($loc, \DateTime $lastmod = null, $changefreq = null, $priority = null)
+    public function __construct($loc, \DateTime $lastmod = null, $changefreq = null, $priority = 0.5)
     {
         $this->setLoc($loc);
         $this->setLastmod($lastmod);


### PR DESCRIPTION
The default page priority should be 0.5, check docs here http://www.sitemaps.org/protocol.html#xmlTagDefinitions .

WARNING: It entails possible BC breaks.