### PR TITLE
[RFC][WIP] Add an event to allow easy decoration of routes

### DIFF
--- a/DependencyInjection/Compiler/AddSitemapRouteListenersPass.php
+++ b/DependencyInjection/Compiler/AddSitemapRouteListenersPass.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the prestaSitemapPlugin package.
+ * (c) David Epely <depely@prestaconcept.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Presta\SitemapBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Presta\SitemapBundle\Event\SitemapRouteEvent;
+
+/**
+ * Registering services tagged with presta.route.listener as actual event listeners
+ *
+ * @author Mathieu Lemoine <mlemoine@mlemoine.name>
+ */
+class AddSitemapRouteListenersPass implements CompilerPassInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('event_dispatcher') && !$container->hasAlias('event_dispatcher')) {
+            return;
+        }
+
+        $definition = $container->findDefinition('event_dispatcher');
+
+        foreach ($container->findTaggedServiceIds('presta.route.listener') as $id => $tags) {
+            $class = $container->getDefinition($id)->getClass();
+
+            $refClass = new \ReflectionClass($class);
+            $interface = 'Presta\SitemapBundle\Service\SitemapRouteListenerInterface';
+            if (!$refClass->implementsInterface($interface)) {
+                throw new \InvalidArgumentException(sprintf('Service "%s" must implement interface "%s".', $id, $interface));
+            }
+            $definition->addMethodCall(
+                'addListenerService',
+                array(SitemapRouteEvent::ON_SITEMAP_ROUTE, array($id, 'decorateUrl'))
+            );
+        }
+    }
+}

--- a/Event/SitemapRouteEvent.php
+++ b/Event/SitemapRouteEvent.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the prestaSitemapPlugin package.
+ * (c) David Epely <depely@prestaconcept.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Presta\SitemapBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+use Presta\SitemapBundle\Sitemap\Url\Url;
+use Presta\SitemapBundle\Sitemap\Url\UrlDecorator;
+
+/**
+ * Manage populate event
+ *
+ * @author Mathieu Lemoine <mlemoine@mlemoine.name>
+ */
+class SitemapRouteEvent extends Event
+{
+    const ON_SITEMAP_ROUTE = 'presta_sitemap.route';
+
+    /**
+     * @var Url
+     */
+    protected $url;
+
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @ar mixed
+     */
+    protected $options;
+    
+    /**
+     * @param Url    $urlContainer
+     * @param string $name
+     * @param mixed  $options
+     */
+    public function __construct(Url $url, $name, $options)
+    {
+        $this->url     = $url;
+        $this->name    = $name;
+        $this->options = $options;
+    }
+
+    /**
+     * @return Url
+     */
+    public function getUrl()
+    {
+        return $this->url;
+    }
+
+    /**
+     * Replace the original Url by a decorated version of it.
+     *
+     * @param UrlDecorator $url
+     */
+    public function setDecoratedUrl(UrlDecorator $url)
+    {
+        $this->url = $url;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getOptions()
+    {
+        return $this->options;
+    }
+}

--- a/Resources/config/route_annotation_listener.xml
+++ b/Resources/config/route_annotation_listener.xml
@@ -10,6 +10,7 @@
     <services>
         <service id="presta_sitemap.eventlistener.route_annotation" class="%presta_sitemap.eventlistener.route_annotation.class%">
             <tag name="presta.sitemap.listener"/>
+            <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="router"/>
         </service>
     </services>

--- a/Service/SitemapListenerInterface.php
+++ b/Service/SitemapListenerInterface.php
@@ -24,6 +24,9 @@ interface SitemapListenerInterface
      * using $event->getUrlContainer()->addUrl(\Presta\SitemapBundle\Sitemap\Url\Url $url, $section)
      * if $event->getSection() is null or matches the listener's section
      *
+     * For each Url, a SitemapRouteEvent should be dispatched to let the chance to any third-party
+     * to decorate the Url and add any suitable extension to the Sitemap.
+     *
      * @param SitemapPopulateEvent $event
      */
     public function populateSitemap(SitemapPopulateEvent $event);

--- a/Service/SitemapRouteListenerInterface.php
+++ b/Service/SitemapRouteListenerInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the prestaSitemapPlugin package.
+ * (c) David Epely <depely@prestaconcept.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Presta\SitemapBundle\Service;
+
+use \Presta\SitemapBundle\Event\SitemapRouteEvent;
+
+/**
+ * Inteface for sitemap route event listeners
+ *
+ * @author Mathieu Lemoine <mlemoine@mlemoine.name>
+ */
+interface SitemapRouteListenerInterface
+{
+    /**
+     * Should check the route in the event and augment the Url as is appropriate
+     *
+     * @param SitemapRouteEvent $event
+     */
+    public function decorateUrl(SitemapRouteEvent $event);
+}

--- a/Tests/EventListener/RouteAnnotationEventListenerTest.php
+++ b/Tests/EventListener/RouteAnnotationEventListenerTest.php
@@ -11,6 +11,8 @@
 
 namespace Presta\SitemapBundle\Test\Sitemap;
 
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
 use Presta\SitemapBundle\EventListener\RouteAnnotationEventListener;
 use Presta\SitemapBundle\Sitemap\Url\UrlConcrete;
 
@@ -21,6 +23,18 @@ use Presta\SitemapBundle\Sitemap\Url\UrlConcrete;
 */
 class RouteAnnotationEventListenerTest extends \PHPUnit_Framework_TestCase
 {
+    protected $dispatcher;
+
+    public function setUp()
+    {
+        if (method_exists($this, 'createMock')) {
+            $this->dispatcher = $this->createMock('Symfony\\Component\\EventDispatcher\\EventDispatcherInterface');
+        } else {
+            $this->dispatcher = $this->getMock('Symfony\\Component\\EventDispatcher\\EventDispatcherInterface');
+        }
+        
+    }
+    
     /**
      * test no "sitemap" annotation
      */
@@ -131,6 +145,7 @@ class RouteAnnotationEventListenerTest extends \PHPUnit_Framework_TestCase
     private function getListener()
     {
         $listener = new RouteAnnotationEventListener(
+            $this->dispatcher,
             $this->getRouter(),
             array(
                 'priority' => 1,


### PR DESCRIPTION
Hello,

Here is a first tentative of implementation of the event I described in #98 

The point of this event is to easily allow for UrlDecoration.

For now, I seem to have found an implementation, but the tests are still missing.

I tried to add the event dispatch in `AbstractGenerator::addUrl`, but I'm missing several informations, mainly the route's name, and possibly the option set. An option would be to add these informations in `UrlConcrete`/`Url`. It seems cleaner and easier to test.

What do you think? I would be more than happy for feedback
- [ ] Write tests
- [ ] Update documentation
