### PR TITLE
Update and rename GoogleImageException.php to GoogleImageUrlDecorator…

### DIFF
--- a/Exception/GoogleImageUrlDecorator.php
+++ b/Exception/GoogleImageUrlDecorator.php
@@ -16,6 +16,6 @@ namespace Presta\SitemapBundle\Exception;
  *
  * @author David Epely <depely@prestaconcept.net>
  */
-class GoogleImageException extends Exception
+class GoogleImageUrlDecorator extends Exception
 {
 }


### PR DESCRIPTION
….php

Maybe this is the correct name for the exception? It's used in: https://github.com/prestaconcept/PrestaSitemapBundle/blob/master/Sitemap/Url/GoogleImageUrlDecorator.php#L35