### PR TITLE
Bugfix - Exception class not found

### DIFF
--- a/Sitemap/Url/GoogleImageUrlDecorator.php
+++ b/Sitemap/Url/GoogleImageUrlDecorator.php
@@ -32,7 +32,7 @@ class GoogleImageUrlDecorator extends UrlDecorator
     public function addImage(GoogleImage $image)
     {
         if ($this->isFull()) {
-            throw new Exception\GoogleImageUrlDecorator('The image limit has been exceeded');
+            throw new Exception\GoogleImageException('The image limit has been exceeded');
         }
 
         $this->imageXml .= $image->toXml();


### PR DESCRIPTION
Using `Presta\SitemapBundle\Exception\GoogleImageException` instead of non-existing
`Presta\SitemapBundle\Exception\GoogleImageUrlDecorator `