### PR TITLE
Allow lastmod to be nullable

### DIFF
--- a/Service/AbstractGenerator.php
+++ b/Service/AbstractGenerator.php
@@ -96,7 +96,7 @@ abstract class AbstractGenerator implements UrlContainerInterface
         }
 
         if ($url instanceof UrlConcrete) {
-            if (null === $url->getLastmod()) {
+            if (null === $url->getLastmod() && null !== $this->defaults['lastmod']) {
                 $url->setLastmod(new \DateTime($this->defaults['lastmod']));
             }
             if (null === $url->getChangefreq()) {

--- a/Tests/Service/GeneratorTest.php
+++ b/Tests/Service/GeneratorTest.php
@@ -76,4 +76,47 @@ class GeneratorTest extends WebTestCase
         $this->assertEquals(count($fullUrlset), 1);
         $this->assertEquals(count($emptyUrlset), 0);
     }
+
+    public function testDefaults()
+    {
+        $this->generator->setDefaults([
+            'priority' => 1,
+            'changefreq' => Sitemap\Url\UrlConcrete::CHANGEFREQ_DAILY,
+            'lastmod' => 'now',
+        ]);
+
+        $url = new Sitemap\Url\UrlConcrete('http://acme.com/');
+
+        $this->assertEquals(null, $url->getPriority());
+        $this->assertEquals(null, $url->getChangefreq());
+        $this->assertEquals(null, $url->getLastmod());
+
+        $this->generator->addUrl($url, 'default');
+
+        // knowing that the generator changes the url instance, we check its properties here
+        $this->assertEquals(1, $url->getPriority());
+        $this->assertEquals(Sitemap\Url\UrlConcrete::CHANGEFREQ_DAILY, $url->getChangefreq());
+        $this->assertInstanceOf('DateTime', $url->getLastmod());
+    }
+
+    public function testNullableDefaults()
+    {
+        $this->generator->setDefaults([
+            'priority' => null,
+            'changefreq' => null,
+            'lastmod' => null,
+        ]);
+
+        $url = new Sitemap\Url\UrlConcrete('http://acme.com/');
+
+        $this->assertEquals(null, $url->getPriority());
+        $this->assertEquals(null, $url->getChangefreq());
+        $this->assertEquals(null, $url->getLastmod());
+
+        $this->generator->addUrl($url, 'default');
+
+        $this->assertEquals(null, $url->getPriority());
+        $this->assertEquals(null, $url->getChangefreq());
+        $this->assertEquals(null, $url->getLastmod());
+    }
 }


### PR DESCRIPTION
Currently the `lastmod` property is not nullable because even if setting the default to `null`, it will be created as `new \DateTime(null)` which resolves to now. This adds a check if the default is actually `null` + tests for the defaults handling.