### PR TITLE
Set default location to public

### DIFF
--- a/Command/DumpSitemapsCommand.php
+++ b/Command/DumpSitemapsCommand.php
@@ -55,7 +55,7 @@ class DumpSitemapsCommand extends ContainerAwareCommand
                 'target',
                 InputArgument::OPTIONAL,
                 'Location where to dump sitemaps. Generated urls will not be related to this folder.',
-                'web'
+                'public'
             );
     }
 


### PR DESCRIPTION
Since symfony 4, public folder is default.