### PR TITLE
Fix LIMIT_BYTES XmlConstraint using new www.sitemaps.org values

### DIFF
--- a/Sitemap/XmlConstraint.php
+++ b/Sitemap/XmlConstraint.php
@@ -21,7 +21,7 @@ namespace Presta\SitemapBundle\Sitemap;
 abstract class XmlConstraint implements \Countable
 {
     const LIMIT_ITEMS = 49999;
-    const LIMIT_BYTES = 10000000; // 10,485,760 bytes - 485,760
+    const LIMIT_BYTES = 50000000; // 52,428,800 bytes - 2,428,800
 
     /**
      * @var bool


### PR DESCRIPTION
Fix values as seen on :
- https://www.sitemaps.org/fr/protocol.html#index
- https://support.google.com/webmasters/answer/183668?hl=en

