### PR TITLE
Add autowiring alias for DumperInterface

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -35,6 +35,8 @@
         <service id="presta_sitemap.dump_command" class="Presta\SitemapBundle\Command\DumpSitemapsCommand" public="true">
             <tag name="console.command"/>
         </service>
+
+        <service id="Presta\SitemapBundle\Service\DumperInterface" alias="presta_sitemap.dumper_default" />
     </services>
 
 </container>

--- a/Tests/DependencyInjection/PrestaSitemapExtensionTest.php
+++ b/Tests/DependencyInjection/PrestaSitemapExtensionTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Presta\SitemapBundle\Test\DependencyInjection;
+
+use Presta\SitemapBundle\DependencyInjection\PrestaSitemapExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class RouteAnnotationEventListenerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDumperAliasIsSet()
+    {
+        $containerBuilder = new ContainerBuilder();
+
+        $extension = new PrestaSitemapExtension();
+        $extension->load(array(), $containerBuilder);
+
+        $this->assertTrue($containerBuilder->hasAlias('Presta\SitemapBundle\Service\DumperInterface'));
+    }
+}


### PR DESCRIPTION
I think it's a common case when you want to trigger sitemap dump in another context and this will leverage the autowiring