### PR TITLE
Dispatch event with correct section when requesting section

### DIFF
--- a/Service/Generator.php
+++ b/Service/Generator.php
@@ -90,7 +90,7 @@ class Generator extends AbstractGenerator implements GeneratorInterface
             return $this->cache->fetch($name);
         }
 
-        $this->generate();
+        $this->populate($name);
 
         if ('root' == $name) {
             return $this->getRoot();

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "issues": "https://github.com/prestaconcept/PrestaSitemapBundle/issues"
     },
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=5.4.0",
         "symfony/framework-bundle": "~2.2|~3.0|~4.0",
         "symfony/console": "~2.2|~3.0|~4.0"
     },


### PR DESCRIPTION
We use your SitemapController and also listen to your event so we can process your Event. Problem is that section of this event is never filled. We want to avoid regenerating whole sitemap again when requesting single section only.

PHP requirement increased because I need $this in closure which is not supported in PHP 5.3 and you don't test for <5.6 anyway.