### PR TITLE
Allow to set the default section for static routes

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -63,6 +63,10 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('lastmod')->defaultValue('now')->end()
                     ->end()
                 ->end()
+                ->scalarNode('default_section')
+                    ->defaultValue('default')
+                    ->info('The default section in which static routes are registered.')
+                ->end()
             ->end()
         ;
 

--- a/DependencyInjection/PrestaSitemapExtension.php
+++ b/DependencyInjection/PrestaSitemapExtension.php
@@ -36,6 +36,7 @@ class PrestaSitemapExtension extends Extension
         $container->setParameter($this->getAlias() . '.sitemap_file_prefix', $config['sitemap_file_prefix']);
         $container->setParameter($this->getAlias() . '.items_by_set', $config['items_by_set']);
         $container->setParameter($this->getAlias() . '.defaults', $config['defaults']);
+        $container->setParameter($this->getAlias() . '.default_section', $config['default_section']);
 
         if (true === $config['route_annotation_listener']) {
             $loader->load('route_annotation_listener.xml');

--- a/EventListener/RouteAnnotationEventListener.php
+++ b/EventListener/RouteAnnotationEventListener.php
@@ -43,11 +43,18 @@ class RouteAnnotationEventListener implements EventSubscriberInterface
     protected $router;
 
     /**
-     * @param RouterInterface $router
+     * @var string
      */
-    public function __construct(RouterInterface $router)
+    private $defaultSection;
+
+    /**
+     * @param RouterInterface $router
+     * @param string          $defaultSection
+     */
+    public function __construct(RouterInterface $router, $defaultSection)
     {
         $this->router = $router;
+        $this->defaultSection = $defaultSection;
     }
 
     /**
@@ -67,7 +74,7 @@ class RouteAnnotationEventListener implements EventSubscriberInterface
     {
         $section = $event->getSection();
 
-        if (is_null($section) || $section == 'default') {
+        if (is_null($section) || $section === $this->defaultSection) {
             $this->addUrlsFromRoutes($event);
         }
     }
@@ -89,7 +96,7 @@ class RouteAnnotationEventListener implements EventSubscriberInterface
                 continue;
             }
 
-            $section = $event->getSection() ?: 'default';
+            $section = $event->getSection() ?: $this->defaultSection;
             if (isset($options['section'])) {
                 $section = $options['section'];
             }

--- a/Resources/config/route_annotation_listener.xml
+++ b/Resources/config/route_annotation_listener.xml
@@ -10,6 +10,7 @@
     <services>
         <service id="presta_sitemap.eventlistener.route_annotation" class="%presta_sitemap.eventlistener.route_annotation.class%">
             <argument type="service" id="router"/>
+            <argument>%presta_sitemap.default_section%</argument>
             <tag name="kernel.event_subscriber"/>
         </service>
     </services>

--- a/Resources/doc/2-configuration.md
+++ b/Resources/doc/2-configuration.md
@@ -13,6 +13,14 @@ presta_sitemap:
         lastmod: now
 ```
 
+Or choose the default sections for static routes:
+
+```yaml
+# config/packages/presta_sitemap.yaml
+presta_sitemap:
+    default_section: default
+```
+
 ## Time to live
 
 You may want to change the default `3600` seconds max-age set when rendering the

--- a/Resources/doc/3-static-routes-usage.md
+++ b/Resources/doc/3-static-routes-usage.md
@@ -11,6 +11,9 @@ The supported sitemap parameters are:
  one of `"always"`, `"hourly"`, `"daily"`, `"weekly"`, `"monthly"`, `"yearly"`, `"never"` (default: `"daily"`)
  * `"priority"`: a number between `0` and `1` (default: `1`)
 
+> **Note** you can change defaults in the bundle configuration.
+> Jump to [dedicated documentation](2-configuration.md) for more information.
+
 
 ## Annotation
 

--- a/Tests/EventListener/RouteAnnotationEventListenerTest.php
+++ b/Tests/EventListener/RouteAnnotationEventListenerTest.php
@@ -130,15 +130,9 @@ class RouteAnnotationEventListenerTest extends \PHPUnit_Framework_TestCase
      */
     private function getListener()
     {
-        $listener = new RouteAnnotationEventListener(
+        return new RouteAnnotationEventListener(
             $this->getRouter(),
-            array(
-                'priority' => 1,
-                'changefreq' => UrlConcrete::CHANGEFREQ_DAILY,
-                'lastmod' => 'now',
-            )
+            'default'
         );
-
-        return $listener;
     }
 }


### PR DESCRIPTION
As suggested in #188 this introduce a new configuration variable, on which `RouteAnnotationEventListener` will rely when registering urls.