### PR TITLE
Allow to configure default dump directory

### DIFF
--- a/Command/DumpSitemapsCommand.php
+++ b/Command/DumpSitemapsCommand.php
@@ -18,7 +18,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
@@ -38,12 +37,18 @@ class DumpSitemapsCommand extends Command
      */
     private $dumper;
 
-    public function __construct(RouterInterface $router, DumperInterface $dumper)
+    /**
+     * @var string
+     */
+    private $defaultTarget;
+
+    public function __construct(RouterInterface $router, DumperInterface $dumper, $defaultTarget)
     {
         parent::__construct(null);
 
         $this->router = $router;
         $this->dumper = $dumper;
+        $this->defaultTarget = $defaultTarget;
     }
 
     /**
@@ -75,7 +80,7 @@ class DumpSitemapsCommand extends Command
                 'target',
                 InputArgument::OPTIONAL,
                 'Location where to dump sitemaps. Generated urls will not be related to this folder.',
-                version_compare(Kernel::VERSION, '4.0') >= 0 ? 'public' : 'web'
+                $this->defaultTarget
             );
     }
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -55,6 +55,14 @@ class Configuration implements ConfigurationInterface
                     ->info('The maximum number of items allowed in single sitemap.')
                 ->end()
                 ->scalarNode('route_annotation_listener')->defaultTrue()->end()
+                ->scalarNode('dump_directory')
+                    ->info(
+                        'The directory to which the sitemap will be dumped. '.
+                        'It can be either absolute, or relative (to the place where the command will be triggered). '.
+                        'Default to Symfony\'s public dir.'
+                    )
+                    ->defaultValue(version_compare(Kernel::VERSION, '4.0') >= 0 ? 'public' : 'web')
+                ->end()
                 ->arrayNode('defaults')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/DependencyInjection/PrestaSitemapExtension.php
+++ b/DependencyInjection/PrestaSitemapExtension.php
@@ -32,6 +32,7 @@ class PrestaSitemapExtension extends Extension
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.xml');
 
+        $container->setParameter($this->getAlias() . '.dump_directory', $config['dump_directory']);
         $container->setParameter($this->getAlias() . '.timetolive', $config['timetolive']);
         $container->setParameter($this->getAlias() . '.sitemap_file_prefix', $config['sitemap_file_prefix']);
         $container->setParameter($this->getAlias() . '.items_by_set', $config['items_by_set']);

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -35,6 +35,7 @@
         <service id="presta_sitemap.dump_command" class="Presta\SitemapBundle\Command\DumpSitemapsCommand" public="true">
             <argument type="service" id="router" />
             <argument type="service" id="presta_sitemap.dumper" />
+            <argument>%presta_sitemap.dump_directory%</argument>
             <tag name="console.command" />
         </service>
 

--- a/Resources/doc/6-dumping-sitemap.md
+++ b/Resources/doc/6-dumping-sitemap.md
@@ -22,19 +22,27 @@ This is called a sitemap **dump**.
 ## Command usage
 
 Command accepts a single argument which is the folder where to dump sitemaps to.
-It defaults to `web`, since most of the people keep the sitemaps in the root of their sites.
+It defaults to `public`, since most of the people keep the sitemaps in the root of their sites.
 
 The command always creates `sitemap.xml` file as sitemaps index.
 Other files are named according to section names you registered.
 
 ```bash
 $ bin/console presta:sitemaps:dump
-Dumping all sections of sitemaps into web directory
+Dumping all sections of sitemaps into public directory
 Created the following sitemap files
     main.xml
     main_0.xml
     sitemap.xml
 ```
+
+> **Note:** Default directory can also be configured in the bundle configuration.
+> ```yaml
+>  # config/packages/presta_sitemap.yaml
+> presta_sitemap:
+>     dump_directory: some/dir
+> ```
+
 
 
 ## What happened?
@@ -85,8 +93,8 @@ You can override Symfony's routing context host if you need to generate several 
 For example:
 
 ```bash
-$ bin/console presta:sitemaps:dump web/sitemap/es/ --base-url=http://es.mysite.com/
-Dumping all sections of sitemaps into web directory
+$ bin/console presta:sitemaps:dump public/sitemap/es/ --base-url=http://es.mysite.com/
+Dumping all sections of sitemaps into public/sitemap/es/ directory
 Created the following sitemap files
     main.xml
     main_0.xml
@@ -100,7 +108,7 @@ The command supports `gzip` compression:
 
 ```bash
 $ bin/console presta:sitemaps:dump --gzip
-Dumping all sections of sitemaps into tmp4 directory
+Dumping all sections of sitemaps into public directory
 Created/Updated the following sitemap files:
     sitemap.default.xml.gz
     sitemap.image.xml.gz

--- a/Tests/Command/DumpSitemapsCommandTest.php
+++ b/Tests/Command/DumpSitemapsCommandTest.php
@@ -127,7 +127,13 @@ class DumpSitemapsCommandTest extends WebTestCase
     private function executeDumpWithOptions(array $input = array())
     {
         $application = new Application(self::$kernel);
-        $application->add(new DumpSitemapsCommand($this->container->get('router'), new Dumper($this->container->get('event_dispatcher'), $this->container->get('filesystem'))));
+        $application->add(
+            new DumpSitemapsCommand(
+                $this->container->get('router'),
+                new Dumper($this->container->get('event_dispatcher'), $this->container->get('filesystem')),
+                'public'
+            )
+        );
 
         $command = $application->find('presta:sitemaps:dump');
         $commandTester = new CommandTester($command);


### PR DESCRIPTION
As suggested in #187 this introduce a new config var to set default dump directory. `DumpSitemapsCommand` is using this value as default value for the `target` argument.