### PR TITLE
Fix default target directory implementation

### DIFF
--- a/Command/DumpSitemapsCommand.php
+++ b/Command/DumpSitemapsCommand.php
@@ -44,11 +44,11 @@ class DumpSitemapsCommand extends Command
 
     public function __construct(RouterInterface $router, DumperInterface $dumper, $defaultTarget)
     {
-        parent::__construct(null);
-
         $this->router = $router;
         $this->dumper = $dumper;
         $this->defaultTarget = $defaultTarget;
+        
+        parent::__construct(null);
     }
 
     /**


### PR DESCRIPTION
The https://github.com/prestaconcept/PrestaSitemapBundle/pull/192 added a new option to configure default target directory. However, the implementation was slightly wrong: `Command::configure()` is called during `Command::construct()` which meant the default target directory was always set to `null` ;)

cc @yann-eugone