### PR TITLE
#201: Add DateTimeInterface support

### DIFF
--- a/Sitemap/Url/GoogleNewsUrlDecorator.php
+++ b/Sitemap/Url/GoogleNewsUrlDecorator.php
@@ -12,6 +12,7 @@
 namespace Presta\SitemapBundle\Sitemap\Url;
 
 use DateTime;
+use DateTimeInterface;
 use Presta\SitemapBundle\Exception;
 use Presta\SitemapBundle\Sitemap\Utils;
 
@@ -56,7 +57,7 @@ class GoogleNewsUrlDecorator extends UrlDecorator
     private $genres = array();
 
     /**
-     * @var DateTime
+     * @var DateTimeInterface|DateTime
      */
     private $publicationDate;
 
@@ -86,11 +87,11 @@ class GoogleNewsUrlDecorator extends UrlDecorator
     private $stockTickers = array();
 
     /**
-     * @param Url       $urlDecorated
-     * @param string    $publicationName
-     * @param string    $publicationLanguage
-     * @param DateTime $publicationDate
-     * @param string    $title
+     * @param Url                        $urlDecorated
+     * @param string                     $publicationName
+     * @param string                     $publicationLanguage
+     * @param DateTimeInterface|DateTime $publicationDate
+     * @param string                     $title
      *
      * @throws Exception\GoogleNewsUrlException
      */
@@ -98,7 +99,7 @@ class GoogleNewsUrlDecorator extends UrlDecorator
         Url $urlDecorated,
         $publicationName,
         $publicationLanguage,
-        DateTime $publicationDate,
+        $publicationDate,
         $title
     ) {
         parent::__construct($urlDecorated);
@@ -110,9 +111,10 @@ class GoogleNewsUrlDecorator extends UrlDecorator
                 'See https://support.google.com/webmasters/answer/74288?hl=en&ref_topic=10078'
             );
         }
-        $this->publicationLanguage = $publicationLanguage;
-        $this->publicationDate = $publicationDate;
-        $this->title = $title;
+
+        $this->setPublicationLanguage($publicationLanguage);
+        $this->setPublicationDate($publicationDate);
+        $this->setTitle($title);
     }
 
     /**
@@ -217,7 +219,7 @@ class GoogleNewsUrlDecorator extends UrlDecorator
     }
 
     /**
-     * @return DateTime
+     * @return DateTimeInterface|DateTime
      */
     public function getPublicationDate()
     {
@@ -225,12 +227,31 @@ class GoogleNewsUrlDecorator extends UrlDecorator
     }
 
     /**
-     * @param DateTime $publicationDate
+     * @param DateTimeInterface|DateTime $publicationDate
      *
      * @return GoogleNewsUrlDecorator
      */
-    public function setPublicationDate(DateTime $publicationDate)
+    public function setPublicationDate($publicationDate)
     {
+        //First condition only triggers for PHP >=5.5, second one supports <5.5
+        if (!($publicationDate instanceof DateTimeInterface || $publicationDate instanceof DateTime)) {
+            $type = is_object($publicationDate) ? \get_class($publicationDate) : \gettype($publicationDate);
+
+            if (\PHP_MAJOR_VERSION >= 7) {
+                throw new \TypeError(
+                    'Argument 1 passed to ' . __METHOD__ .
+                    "() must be an instance of DateTimeInterface, '$type' given"
+                );
+            }
+
+            \trigger_error(
+                'Argument 1 passed to ' . __METHOD__ . "() must be an instance of DateTime, '$type' given",
+                E_USER_ERROR
+            );
+
+            return $this;
+        }
+
         $this->publicationDate = $publicationDate;
 
         return $this;

--- a/Sitemap/Url/UrlConcrete.php
+++ b/Sitemap/Url/UrlConcrete.php
@@ -12,6 +12,7 @@
 namespace Presta\SitemapBundle\Sitemap\Url;
 
 use DateTime;
+use DateTimeInterface;
 use Presta\SitemapBundle\Sitemap\Utils;
 
 /**
@@ -36,7 +37,7 @@ class UrlConcrete implements Url
     protected $loc;
 
     /**
-     * @var DateTime|null
+     * @var DateTimeInterface|DateTime|null
      */
     protected $lastmod;
 
@@ -53,12 +54,12 @@ class UrlConcrete implements Url
     /**
      * Construct a new basic url
      *
-     * @param string        $loc        Absolute url
-     * @param DateTime|null $lastmod    Last modification date
-     * @param string|null   $changefreq Change frequency
-     * @param float|null    $priority   Priority
+     * @param string                          $loc        Absolute url
+     * @param DateTimeInterface|DateTime|null $lastmod    Last modification date
+     * @param string|null                     $changefreq Change frequency
+     * @param float|null                      $priority   Priority
      */
-    public function __construct($loc, DateTime $lastmod = null, $changefreq = null, $priority = null)
+    public function __construct($loc, $lastmod = null, $changefreq = null, $priority = null)
     {
         $this->setLoc($loc);
         $this->setLastmod($lastmod);
@@ -87,19 +88,38 @@ class UrlConcrete implements Url
     }
 
     /**
-     * @param DateTime|null $lastmod
+     * @param DateTimeInterface|DateTime|null $lastmod
      *
      * @return UrlConcrete
      */
-    public function setLastmod(DateTime $lastmod = null)
+    public function setLastmod($lastmod = null)
     {
+        //First condition only triggers for PHP >=5.5, second one supports <5.5
+        if ($lastmod !== null && !($lastmod instanceof DateTimeInterface || $lastmod instanceof DateTime)) {
+            $type = is_object($lastmod) ? \get_class($lastmod) : \gettype($lastmod);
+
+            if (\PHP_MAJOR_VERSION >= 7) {
+                throw new \TypeError(
+                    'Argument 1 passed to ' . __METHOD__ .
+                    "() must be an instance of DateTimeInterface or null, '$type' given"
+                );
+            }
+
+            \trigger_error(
+                'Argument 1 passed to ' . __METHOD__ . "() must be an instance of DateTime or null, '$type' given",
+                \E_USER_ERROR
+            );
+
+            return $this;
+        }
+
         $this->lastmod = $lastmod;
 
         return $this;
     }
 
     /**
-     * @return DateTime|null
+     * @return DateTimeInterface|DateTime|null
      */
     public function getLastmod()
     {

--- a/Tests/Sitemap/Url/GoogleNewsUrlDecoratorTest.php
+++ b/Tests/Sitemap/Url/GoogleNewsUrlDecoratorTest.php
@@ -76,6 +76,26 @@ class GoogleNewsUrlDecoratorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test the \DateTimeImmutable support
+     * @requires PHP >= 5.5
+     */
+    public function testImmutableDateTime()
+    {
+        $date = new \DateTimeImmutable('2011-10-01 11:22:33');
+
+        // test date only format
+        $url = $this->createExampleUrl();
+        $url->setPublicationDate($date);
+        $url->setPublicationDateFormat(GoogleNewsUrlDecorator::DATE_FORMAT_DATE);
+        $dom = new \DOMDocument();
+        $dom->loadXML($this->generateXml($url));
+
+        $dateNodes = $dom->getElementsByTagNameNS('http://www.google.com/schemas/sitemap-news/0.9', 'publication_date');
+        $this->assertEquals(1, $dateNodes->length, 'Could not find news:publication_date tag');
+        $this->assertEquals($date->format('Y-m-d'), $dateNodes->item(0)->textContent, 'Date was not formatted properly');
+    }
+
+    /**
      * Tests if the news access property is validated properly.
      */
     public function testAccessPropertyValidation()

--- a/Tests/Sitemap/Url/UrlConcreteTest.php
+++ b/Tests/Sitemap/Url/UrlConcreteTest.php
@@ -29,7 +29,7 @@ class UrlConcreteTest extends \PHPUnit_Framework_TestCase
 
     public function testToXmlProvider()
     {
-        return array(
+        $cases = array(
             array('<url><loc>http://example.com/</loc></url>', 'http://example.com/'),
             array('<url><loc>http://example.com/abcd</loc></url>', 'http://example.com/abcd'),
             array('<url><loc>http://example.com/abcd/?a=1&amp;b=cdf</loc></url>', 'http://example.com/abcd/?a=1&b=cdf'),
@@ -47,5 +47,11 @@ class UrlConcreteTest extends \PHPUnit_Framework_TestCase
             array('<url><loc>http://example.com/abcd/?a=1&amp;b=cdf&amp;ghj=ijklmn</loc><lastmod>2012-01-01T00:00:00+00:00</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>', 'http://example.com/abcd/?a=1&b=cdf&ghj=ijklmn', new \DateTime('2012-1-1 00:00:00', new \DateTimeZone('Europe/London')), 'daily', 0.7),
             array('<url><loc>http://example.com/abcd/?a=1&amp;b=cdf&amp;ghj=ijklmn</loc><changefreq>daily</changefreq><priority>0.7</priority></url>', 'http://example.com/abcd/?a=1&b=cdf&ghj=ijklmn', null, 'daily', 0.7),
         );
+
+        if (\version_compare(\PHP_VERSION, '5.5.0', '>=')) {
+            $cases[] = array('<url><loc>http://example.com/abcd/?a=1&amp;b=cdf&amp;ghj=ijklmn</loc><lastmod>2010-02-13T00:00:00+00:00</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>', 'http://example.com/abcd/?a=1&b=cdf&ghj=ijklmn', new \DateTimeImmutable('2010-2-13 00:00:00', new \DateTimeZone('Europe/London')), 'daily', 0.7);
+        }
+
+        return $cases;
     }
 }


### PR DESCRIPTION
As discussed in #201 I implemented support for `DateTimeInterface` for the `UrlConcrete`. I also found that `DateTime` was used in Google News & Google Video sitemaps - I fixed only the first one, since GVideo is long time gone ;)

Closes #201