### PR TITLE
Add missing Content-Type text/xml header

### DIFF
--- a/Controller/SitemapController.php
+++ b/Controller/SitemapController.php
@@ -57,6 +57,7 @@ class SitemapController
         }
 
         $response = Response::create($sitemapindex->toXml());
+        $response->headers->set('Content-Type', 'text/xml');
         $response->setPublic();
         $response->setClientTtl($this->ttl);
 
@@ -79,6 +80,7 @@ class SitemapController
         }
 
         $response = Response::create($section->toXml());
+        $response->headers->set('Content-Type', 'text/xml');
         $response->setPublic();
         $response->setClientTtl($this->ttl);
 

--- a/Tests/Controller/SitemapControllerTest.php
+++ b/Tests/Controller/SitemapControllerTest.php
@@ -73,12 +73,14 @@ class SitemapControllerTest extends WebTestCase
     {
         $response = $this->controller->indexAction();
         self::assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
+        self::assertEquals('text/xml', $response->headers->get('Content-Type'));
     }
 
     public function testValidSectionAction()
     {
         $response = $this->controller->sectionAction('default');
         self::assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
+        self::assertEquals('text/xml', $response->headers->get('Content-Type'));
     }
 
     /**


### PR DESCRIPTION
Currently, without dumping sitemap, controller response serving text/html Content-Type header. This fix setting up correct header for xml sitemap.