### PR TITLE
Fixes PS4 tests autoloading

### DIFF
--- a/Tests/DependencyInjection/PrestaSitemapExtensionTest.php
+++ b/Tests/DependencyInjection/PrestaSitemapExtensionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Presta\SitemapBundle\Test\DependencyInjection;
+namespace Presta\SitemapBundle\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
 use Presta\SitemapBundle\DependencyInjection\PrestaSitemapExtension;

--- a/Tests/DependencyInjection/PrestaSitemapExtensionTest.php
+++ b/Tests/DependencyInjection/PrestaSitemapExtensionTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Presta\SitemapBundle\DependencyInjection\PrestaSitemapExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class RouteAnnotationEventListenerTest extends TestCase
+class PrestaSitemapExtensionTest extends TestCase
 {
     public function testDumperAliasIsSet()
     {

--- a/Tests/EventListener/RouteAnnotationEventListenerTest.php
+++ b/Tests/EventListener/RouteAnnotationEventListenerTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Presta\SitemapBundle\Test\Sitemap;
+namespace Presta\SitemapBundle\Tests\Sitemap;
 
 use PHPUnit\Framework\TestCase;
 use Presta\SitemapBundle\EventListener\RouteAnnotationEventListener;

--- a/Tests/EventListener/RouteAnnotationEventListenerTest.php
+++ b/Tests/EventListener/RouteAnnotationEventListenerTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Presta\SitemapBundle\Tests\Sitemap;
+namespace Presta\SitemapBundle\Tests\EventListener;
 
 use PHPUnit\Framework\TestCase;
 use Presta\SitemapBundle\EventListener\RouteAnnotationEventListener;

--- a/Tests/Service/GeneratorTest.php
+++ b/Tests/Service/GeneratorTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Presta\SitemapBundle\Tests\Sitemap;
+namespace Presta\SitemapBundle\Tests\Service;
 
 use Presta\SitemapBundle\Event\SitemapPopulateEvent;
 use Presta\SitemapBundle\Service\Generator;

--- a/Tests/Service/GeneratorTest.php
+++ b/Tests/Service/GeneratorTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Presta\SitemapBundle\Test\Sitemap;
+namespace Presta\SitemapBundle\Tests\Sitemap;
 
 use Presta\SitemapBundle\Event\SitemapPopulateEvent;
 use Presta\SitemapBundle\Service\Generator;

--- a/Tests/Sitemap/SitemapindexTest.php
+++ b/Tests/Sitemap/SitemapindexTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Presta\SitemapBundle\Test\Sitemap;
+namespace Presta\SitemapBundle\Tests\Sitemap;
 
 use PHPUnit\Framework\TestCase;
 use Presta\SitemapBundle\Sitemap;

--- a/Tests/Sitemap/Url/GoogleImageTest.php
+++ b/Tests/Sitemap/Url/GoogleImageTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Presta\SitemapBundle\Test\Sitemap\Url;
+namespace Presta\SitemapBundle\Tests\Sitemap\Url;
 
 use PHPUnit\Framework\TestCase;
 use Presta\SitemapBundle\Sitemap;

--- a/Tests/Sitemap/Url/GoogleImageUrlDecoratorTest.php
+++ b/Tests/Sitemap/Url/GoogleImageUrlDecoratorTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Presta\SitemapBundle\Test\Sitemap\Url;
+namespace Presta\SitemapBundle\Tests\Sitemap\Url;
 
 use PHPUnit\Framework\TestCase;
 use Presta\SitemapBundle\Sitemap;

--- a/Tests/Sitemap/Url/GoogleMobileUrlDecoratorTest.php
+++ b/Tests/Sitemap/Url/GoogleMobileUrlDecoratorTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Presta\SitemapBundle\Test\Sitemap\Url;
+namespace Presta\SitemapBundle\Tests\Sitemap\Url;
 
 use PHPUnit\Framework\TestCase;
 use Presta\SitemapBundle\Sitemap;

--- a/Tests/Sitemap/Url/GoogleMultilangUrlDecoratorTest.php
+++ b/Tests/Sitemap/Url/GoogleMultilangUrlDecoratorTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Presta\SitemapBundle\Test\Sitemap\Url;
+namespace Presta\SitemapBundle\Tests\Sitemap\Url;
 
 use PHPUnit\Framework\TestCase;
 use Presta\SitemapBundle\Sitemap;

--- a/Tests/Sitemap/Url/GoogleNewsUrlDecoratorTest.php
+++ b/Tests/Sitemap/Url/GoogleNewsUrlDecoratorTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Presta\SitemapBundle\Test\Sitemap\Url;
+namespace Presta\SitemapBundle\Tests\Sitemap\Url;
 
 use PHPUnit\Framework\TestCase;
 use Presta\SitemapBundle\Exception\GoogleNewsUrlException;

--- a/Tests/Sitemap/Url/GoogleVideoUrlDecoratorTest.php
+++ b/Tests/Sitemap/Url/GoogleVideoUrlDecoratorTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Presta\SitemapBundle\Test\Sitemap\Url;
+namespace Presta\SitemapBundle\Tests\Sitemap\Url;
 
 use PHPUnit\Framework\TestCase;
 use Presta\SitemapBundle\Sitemap\Url\GoogleVideoUrlDecorator;

--- a/Tests/Sitemap/Url/UrlConcreteTest.php
+++ b/Tests/Sitemap/Url/UrlConcreteTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Presta\SitemapBundle\Test\Sitemap\Url;
+namespace Presta\SitemapBundle\Tests\Sitemap\Url;
 
 use PHPUnit\Framework\TestCase;
 use Presta\SitemapBundle\Sitemap\Url\UrlConcrete;

--- a/Tests/Sitemap/UrlsetTest.php
+++ b/Tests/Sitemap/UrlsetTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Presta\SitemapBundle\Test\Sitemap;
+namespace Presta\SitemapBundle\Tests\Sitemap;
 
 use PHPUnit\Framework\TestCase;
 use Presta\SitemapBundle\Sitemap;

--- a/Tests/Sitemap/UtilsTest.php
+++ b/Tests/Sitemap/UtilsTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Presta\SitemapBundle\Test\Sitemap;
+namespace Presta\SitemapBundle\Tests\Sitemap;
 
 use PHPUnit\Framework\TestCase;
 use Presta\SitemapBundle\Exception\Exception;

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,10 @@
     "autoload": {
         "psr-4": {
             "Presta\\SitemapBundle\\": ""
-        }
+        },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
     },
     "autoload-dev": {
         "files": [


### PR DESCRIPTION
Composer 1.10+ complains that the test classes do not comply with psr-4 autoloading standard and won't be loaded in composer 1.11.

This can be replicated by updating composer to the latest snapshot (`composer self-update --snapshot`) and then running `composer install -o`

Looking at official Symfony modules, they use this method to fix the issue.