### PR TITLE
Fix invalid routing config on Symfony < 4.1

### DIFF
--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,11 +1,11 @@
 PrestaSitemapBundle_index:
     path:     "/%presta_sitemap.sitemap_file_prefix%.{_format}"
-    defaults: { _controller: presta_sitemap.controller::indexAction }
+    defaults: { _controller: Presta\SitemapBundle\Controller\SitemapController::indexAction }
     requirements:
         _format: xml
 
 PrestaSitemapBundle_section:
     path:     "/%presta_sitemap.sitemap_file_prefix%.{name}.{_format}"
-    defaults: { _controller: presta_sitemap.controller::sectionAction }
+    defaults: { _controller: Presta\SitemapBundle\Controller\SitemapController::sectionAction }
     requirements:
         _format: xml

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -40,6 +40,7 @@
         </service>
 
         <service id="Presta\SitemapBundle\Service\DumperInterface" alias="presta_sitemap.dumper_default" />
+        <service id="Presta\SitemapBundle\Controller\SitemapController" alias="presta_sitemap.controller" public="true" />
 
         <service id="presta_sitemap.controller" class="Presta\SitemapBundle\Controller\SitemapController" public="true">
             <argument type="service" id="presta_sitemap.generator" />


### PR DESCRIPTION
Fixes https://github.com/prestaconcept/PrestaSitemapBundle/issues/221. Was regression from https://github.com/prestaconcept/PrestaSitemapBundle/pull/213