### PR TITLE
Allow to set defaults on decorated routes

### DIFF
--- a/Service/AbstractGenerator.php
+++ b/Service/AbstractGenerator.php
@@ -15,6 +15,7 @@ use Presta\SitemapBundle\Event\SitemapPopulateEvent;
 use Presta\SitemapBundle\Sitemap\Sitemapindex;
 use Presta\SitemapBundle\Sitemap\Url\Url;
 use Presta\SitemapBundle\Sitemap\Url\UrlConcrete;
+use Presta\SitemapBundle\Sitemap\Url\UrlDecorator;
 use Presta\SitemapBundle\Sitemap\Urlset;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as ContractsEventDispatcherInterface;
@@ -96,15 +97,16 @@ abstract class AbstractGenerator implements UrlContainerInterface
             throw new \RuntimeException('The limit of sitemapindex has been exceeded');
         }
 
-        if ($url instanceof UrlConcrete) {
-            if (null === $url->getLastmod() && null !== $this->defaults['lastmod']) {
-                $url->setLastmod(new \DateTimeImmutable($this->defaults['lastmod']));
+        $concreteUrl = $this->getUrlConcrete($url);
+        if ($concreteUrl instanceof UrlConcrete) {
+            if (null === $concreteUrl->getLastmod() && null !== $this->defaults['lastmod']) {
+                $concreteUrl->setLastmod(new \DateTimeImmutable($this->defaults['lastmod']));
             }
-            if (null === $url->getChangefreq()) {
-                $url->setChangefreq($this->defaults['changefreq']);
+            if (null === $concreteUrl->getChangefreq()) {
+                $concreteUrl->setChangefreq($this->defaults['changefreq']);
             }
-            if (null === $url->getPriority()) {
-                $url->setPriority($this->defaults['priority']);
+            if (null === $concreteUrl->getPriority()) {
+                $concreteUrl->setPriority($this->defaults['priority']);
             }
         }
 
@@ -167,5 +169,23 @@ abstract class AbstractGenerator implements UrlContainerInterface
         }
 
         return $this->root;
+    }
+
+    /**
+     * @param Url $url
+     *
+     * @return Url|null
+     */
+    private function getUrlConcrete(Url $url)
+    {
+        if ($url instanceof UrlConcrete) {
+            return $url;
+        }
+
+        if ($url instanceof UrlDecorator) {
+            return $this->getUrlConcrete($url->getUrlDecorated());
+        }
+
+        return null;
     }
 }

--- a/Sitemap/Url/UrlDecorator.php
+++ b/Sitemap/Url/UrlDecorator.php
@@ -43,4 +43,12 @@ abstract class UrlDecorator implements Url
     {
         return array_merge($this->urlDecorated->getCustomNamespaces(), $this->customNamespaces);
     }
+
+    /**
+     * @return Url
+     */
+    public function getUrlDecorated()
+    {
+        return $this->urlDecorated;
+    }
 }

--- a/Tests/Command/DumpSitemapsCommandTest.php
+++ b/Tests/Command/DumpSitemapsCommandTest.php
@@ -69,7 +69,8 @@ class DumpSitemapsCommandTest extends WebTestCase
                         ->setGalleryLoc($base_url . 'page_video1/gallery_loc/?p=1&sort=desc')
                         ->setGalleryLocTitle('Gallery title & spécial chars');
 
-                    $urlVideo = new GoogleVideoUrlDecorator(new UrlConcrete($base_url . 'page_video1/'));
+                    $urlVideo = new GoogleVideoUrlDecorator($concrete = new UrlConcrete($base_url . 'page_video1/'));
+                    $concrete->setLastmod(new \DateTimeImmutable('2020-03-01T17:48:38+01:00'));
                     $urlVideo->addVideo($video);
 
                     $event->getUrlContainer()->addUrl($urlVideo, 'video');

--- a/Tests/Service/GeneratorTest.php
+++ b/Tests/Service/GeneratorTest.php
@@ -157,4 +157,30 @@ class GeneratorTest extends WebTestCase
         self::assertEquals(null, $url->getChangefreq());
         self::assertEquals(null, $url->getLastmod());
     }
+
+    public function testDefaultsDecoratedUrl()
+    {
+        $this->generator->setDefaults([
+            'priority' => 1,
+            'changefreq' => Sitemap\Url\UrlConcrete::CHANGEFREQ_DAILY,
+            'lastmod' => 'now',
+        ]);
+
+        $url = new Sitemap\Url\GoogleMultilangUrlDecorator(
+            new Sitemap\Url\GoogleImageUrlDecorator(
+                $urlConcrete = new Sitemap\Url\UrlConcrete('http://acme.com/')
+            )
+        );
+
+        self::assertEquals(null, $urlConcrete->getPriority());
+        self::assertEquals(null, $urlConcrete->getChangefreq());
+        self::assertEquals(null, $urlConcrete->getLastmod());
+
+        $this->generator->addUrl($url, 'default');
+
+        // knowing that the generator changes the url instance, we check its properties here
+        self::assertEquals(1, $urlConcrete->getPriority());
+        self::assertEquals(Sitemap\Url\UrlConcrete::CHANGEFREQ_DAILY, $urlConcrete->getChangefreq());
+        self::assertInstanceOf('DateTimeInterface', $urlConcrete->getLastmod());
+    }
 }

--- a/Tests/fixtures/sitemap.video.xml
+++ b/Tests/fixtures/sitemap.video.xml
@@ -3,6 +3,9 @@
         xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
   <url>
     <loc>http://sitemap.php54.local/page_video1/</loc>
+    <lastmod>2020-03-01T17:48:38+01:00</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>1.0</priority>
     <video:video>
       <video:thumbnail_loc>http://sitemap.php54.local/page_video1/thumbnail_loc?a=b&amp;b=c</video:thumbnail_loc>
       <video:title><![CDATA[Title & spécial chars]]></video:title>


### PR DESCRIPTION
This is supposed to fix #228 

We noticed that `AbstractGenerator` is only setting `changefreq`, `lastmod` & `priority` to instances of `UrlConcrete`.

This is not the expected behavior as all urls can have these xml properties.

With that pull request `AbstractGenerator` will dive in decorated chain of urls until it find an `UrlConcrete` (or not) and set these defaults to that url.