### PR TITLE
Default dump dir made absolute, using kernel.project_dir parameter

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -61,7 +61,9 @@ class Configuration implements ConfigurationInterface
                         'It can be either absolute, or relative (to the place where the command will be triggered). '.
                         'Default to Symfony\'s public dir.'
                     )
-                    ->defaultValue(version_compare(Kernel::VERSION, '4.0') >= 0 ? 'public' : 'web')
+                    ->defaultValue(
+                        '%kernel.project_dir%/'.(version_compare(Kernel::VERSION, '4.0') >= 0 ? 'public' : 'web')
+                    )
                 ->end()
                 ->arrayNode('defaults')
                     ->addDefaultsIfNotSet()


### PR DESCRIPTION
Should fix #225

Configuration `dump_directory` was prefixed with `%kernel.project_dir%` (which was added as of Symfony `3.3`).