### PR TITLE
Fix symfony 5.1 deprecations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
           - php-version: 7.4
             symfony-version: 4.4.*
           - php-version: 7.2
-            symfony-version: 5.0.*
+            symfony-version: 5.1.*
           - php-version: 7.4
-            symfony-version: 5.0.*
+            symfony-version: 5.1.*
 
     steps:
       - name: "Checkout"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ matrix:
         - php: 7.4
           env: SYMFONY_VERSION=4.4.*
         - php: 7.2
-          env: SYMFONY_VERSION=5.0.*
+          env: SYMFONY_VERSION=5.1.*
         - php: 7.4
-          env: SYMFONY_VERSION=5.0.*
+          env: SYMFONY_VERSION=5.1.*
 
 env:
     global:

--- a/Controller/SitemapController.php
+++ b/Controller/SitemapController.php
@@ -56,7 +56,7 @@ class SitemapController
             throw new NotFoundHttpException('Not found');
         }
 
-        $response = Response::create($sitemapindex->toXml());
+        $response = new Response($sitemapindex->toXml());
         $response->headers->set('Content-Type', 'text/xml');
         $response->setPublic();
         $response->setClientTtl($this->ttl);
@@ -79,7 +79,7 @@ class SitemapController
             throw new NotFoundHttpException('Not found');
         }
 
-        $response = Response::create($section->toXml());
+        $response = new Response($section->toXml());
         $response->headers->set('Content-Type', 'text/xml');
         $response->setPublic();
         $response->setClientTtl($this->ttl);

--- a/Tests/Integration/config/routing.yaml
+++ b/Tests/Integration/config/routing.yaml
@@ -1,0 +1,3 @@
+framework:
+    router:
+        utf8: true

--- a/Tests/Integration/src/ContainerConfiguratorTrait.php
+++ b/Tests/Integration/src/ContainerConfiguratorTrait.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Presta\SitemapBundle\Tests\Integration;
+
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\HttpKernel\Kernel;
+
+if (Kernel::VERSION_ID >= 50100) {
+    trait ContainerConfiguratorTrait
+    {
+        protected function configureContainer(ContainerConfigurator $container): void
+        {
+            $confDir = $this->getProjectDir() . '/config';
+            
+            $container->import($confDir . '/{packages}/*' . self::CONFIG_EXTS);
+            $container->import($confDir . '/{packages}/' . $this->environment . '/*' . self::CONFIG_EXTS);
+            $container->import($confDir . '/{services}' . self::CONFIG_EXTS);
+            $container->import($confDir . '/{services}_' . $this->environment . self::CONFIG_EXTS);
+            $container->import($confDir . '/routing.yaml');
+        }
+    }
+} else {
+    trait ContainerConfiguratorTrait
+    {
+        protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader)
+        {
+            $confDir = $this->getProjectDir() . '/config';
+
+            $loader->load($confDir . '/{packages}/*' . self::CONFIG_EXTS, 'glob');
+            $loader->load($confDir . '/{packages}/' . $this->environment . '/*' . self::CONFIG_EXTS, 'glob');
+            $loader->load($confDir . '/{services}' . self::CONFIG_EXTS, 'glob');
+            $loader->load($confDir . '/{services}_' . $this->environment . self::CONFIG_EXTS, 'glob');
+
+            if (self::VERSION_ID >= 40200) {
+                $loader->load($confDir . '/routing.yaml');
+            }
+        }
+    }
+}

--- a/Tests/Integration/src/Controller/ArchivesController.php
+++ b/Tests/Integration/src/Controller/ArchivesController.php
@@ -12,6 +12,6 @@ final class ArchivesController
      */
     public function archive(): Response
     {
-        return Response::create(__FUNCTION__);
+        return new Response(__FUNCTION__);
     }
 }

--- a/Tests/Integration/src/Controller/BlogController.php
+++ b/Tests/Integration/src/Controller/BlogController.php
@@ -12,7 +12,7 @@ final class BlogController
      */
     public function read(): Response
     {
-        return Response::create(__FUNCTION__);
+        return new Response(__FUNCTION__);
     }
 
     /**
@@ -20,6 +20,6 @@ final class BlogController
      */
     public function post(string $slug): Response
     {
-        return Response::create(__FUNCTION__ . ':' . $slug);
+        return new Response(__FUNCTION__ . ':' . $slug);
     }
 }

--- a/Tests/Integration/src/Controller/StaticController.php
+++ b/Tests/Integration/src/Controller/StaticController.php
@@ -12,16 +12,16 @@ final class StaticController
      */
     public function home(): Response
     {
-        return Response::create(__FUNCTION__);
+        return new Response(__FUNCTION__);
     }
 
     public function contact(): Response
     {
-        return Response::create(__FUNCTION__);
+        return new Response(__FUNCTION__);
     }
 
     public function company(): Response
     {
-        return Response::create(__FUNCTION__);
+        return new Response(__FUNCTION__);
     }
 }

--- a/Tests/Integration/src/Kernel.php
+++ b/Tests/Integration/src/Kernel.php
@@ -3,15 +3,14 @@
 namespace Presta\SitemapBundle\Tests\Integration;
 
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
-use Symfony\Component\Config\Loader\LoaderInterface;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
-use Symfony\Component\Routing\RouteCollectionBuilder;
 
 class Kernel extends BaseKernel
 {
+    use ContainerConfiguratorTrait;
     use MicroKernelTrait;
+    use RouteConfiguratorTrait;
 
     const CONFIG_EXTS = '.{php,xml,yaml,yml}';
 
@@ -36,25 +35,6 @@ class Kernel extends BaseKernel
             new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
             new \Presta\SitemapBundle\PrestaSitemapBundle(),
         ];
-    }
-
-    protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader)
-    {
-        $confDir = $this->getProjectDir() . '/config';
-
-        $loader->load($confDir . '/{packages}/*' . self::CONFIG_EXTS, 'glob');
-        $loader->load($confDir . '/{packages}/' . $this->environment . '/*' . self::CONFIG_EXTS, 'glob');
-        $loader->load($confDir . '/{services}' . self::CONFIG_EXTS, 'glob');
-        $loader->load($confDir . '/{services}_' . $this->environment . self::CONFIG_EXTS, 'glob');
-    }
-
-    protected function configureRoutes(RouteCollectionBuilder $routes)
-    {
-        $confDir = $this->getProjectDir() . '/config';
-
-        $routes->import($confDir . '/{routes}/' . $this->environment . '/*' . self::CONFIG_EXTS, '/', 'glob');
-        $routes->import($confDir . '/{routes}/*' . self::CONFIG_EXTS, '/', 'glob');
-        $routes->import($confDir . '/{routes}' . self::CONFIG_EXTS, '/', 'glob');
     }
 
     public function boot()

--- a/Tests/Integration/src/RouteConfiguratorTrait.php
+++ b/Tests/Integration/src/RouteConfiguratorTrait.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Presta\SitemapBundle\Tests\Integration;
+
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+use Symfony\Component\Routing\RouteCollectionBuilder;
+
+if (Kernel::VERSION_ID >= 50100) {
+    trait RouteConfiguratorTrait
+    {
+        protected function configureRoutes(RoutingConfigurator $routes)
+        {
+            $confDir = $this->getProjectDir() . '/config';
+
+            $routes->import($confDir . '/{routes}/' . $this->environment . '/*' . self::CONFIG_EXTS);
+            $routes->import($confDir . '/{routes}/*' . self::CONFIG_EXTS);
+            $routes->import($confDir . '/{routes}' . self::CONFIG_EXTS);
+        }
+    }
+} else {
+    trait RouteConfiguratorTrait
+    {
+        protected function configureRoutes(RouteCollectionBuilder $routes)
+        {
+            $confDir = $this->getProjectDir() . '/config';
+
+            $routes->import($confDir . '/{routes}/' . $this->environment . '/*' . self::CONFIG_EXTS, '/', 'glob');
+            $routes->import($confDir . '/{routes}/*' . self::CONFIG_EXTS, '/', 'glob');
+            $routes->import($confDir . '/{routes}' . self::CONFIG_EXTS, '/', 'glob');
+        }
+    }
+}


### PR DESCRIPTION
Fix these deprecations:
```
  6x: Since symfony/framework-bundle 5.1: Using type "Symfony\Component\Routing\RouteCollectionBuilder" for argument 1 of method "Presta\SitemapBundle\Tests\Integration\Kernel:configureRoutes()" is deprecated, use "Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator" instead.
    3x in HttpTest::testAccessSitemapWithHttp from Presta\SitemapBundle\Tests\Integration\Tests
    2x in CliTest::testDumpSitemapUsingCLI from Presta\SitemapBundle\Tests\Integration\Tests
    1x in CliTest::testGzipLinksArePreservedOnPartialDump from Presta\SitemapBundle\Tests\Integration\Tests

  5x: Since symfony/http-foundation 5.1: The "Symfony\Component\HttpFoundation\Response::create()" method is deprecated, use "new Symfony\Component\HttpFoundation\Response()" instead.
    3x in HttpTest::testAccessSitemapWithHttp from Presta\SitemapBundle\Tests\Integration\Tests
    1x in SitemapControllerTest::testIndexSuccesful from Presta\SitemapBundle\Tests\Unit\Controller
    1x in SitemapControllerTest::testSectionSuccessful from Presta\SitemapBundle\Tests\Unit\Controller

  1x: Since symfony/framework-bundle 5.1: Not setting the "framework.router.utf8" configuration option is deprecated, it will default to "true" in version 6.0.
    1x in CliTest::testDumpSitemapUsingCLI from Presta\SitemapBundle\Tests\Integration\Tests

  1x: Since symfony/routing 5.1: The "Symfony\Component\Routing\RouteCollectionBuilder" class is deprecated, use "Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator" instead.
    1x in CliTest::testDumpSitemapUsingCLI from Presta\SitemapBundle\Tests\Integration\Tests
```