### PR TITLE
Update tests CS

### DIFF
--- a/Tests/Integration/tests/CliTest.php
+++ b/Tests/Integration/tests/CliTest.php
@@ -64,7 +64,7 @@ class CliTest extends SitemapTestCase
     /**
      * @dataProvider gzip
      */
-    public function testDumpSitemapUsingCLI(bool $gzip)
+    public function testDumpSitemapUsingCLI(bool $gzip): void
     {
         $index = $this->index();
         self::assertFileNotExists($index, 'Sitemap index file does not exists before dump');

--- a/Tests/Integration/tests/HttpTest.php
+++ b/Tests/Integration/tests/HttpTest.php
@@ -2,7 +2,6 @@
 
 namespace Presta\SitemapBundle\Tests\Integration\Tests;
 
-use Symfony\Component\BrowserKit\AbstractBrowser;
 use Symfony\Component\HttpFoundation\Request;
 
 class HttpTest extends SitemapTestCase
@@ -10,7 +9,7 @@ class HttpTest extends SitemapTestCase
     private const GET = Request::METHOD_GET;
     private const XML = 'text/xml; charset=UTF-8';
 
-    public function testAccessSitemapWithHttp()
+    public function testAccessSitemapWithHttp(): void
     {
         $web = self::createClient();
 

--- a/Tests/Integration/tests/MessengerTest.php
+++ b/Tests/Integration/tests/MessengerTest.php
@@ -19,7 +19,7 @@ class MessengerTest extends SitemapTestCase
     protected function setUp(): void
     {
         if (!interface_exists(MessageBusInterface::class)) {
-            $this->markTestSkipped('Skipping messenger tests, because it is not installed.');
+            self::markTestSkipped('Skipping messenger tests, because it is not installed.');
 
             return;
         }

--- a/Tests/Integration/tests/SitemapTestCase.php
+++ b/Tests/Integration/tests/SitemapTestCase.php
@@ -8,7 +8,7 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 abstract class SitemapTestCase extends WebTestCase
 {
-    protected static function assertIndex(string $xml, bool $gzip = false)
+    protected static function assertIndex(string $xml, bool $gzip = false): void
     {
         $index = simplexml_load_string($xml);
         $index->registerXPathNamespace('sm', 'http://www.sitemaps.org/schemas/sitemap/0.9');
@@ -19,7 +19,7 @@ abstract class SitemapTestCase extends WebTestCase
         self::assertIndexContainsSectionLink($index, 'archives_0', $gzip);
     }
 
-    protected static function assertStaticSection(string $xml)
+    protected static function assertStaticSection(string $xml): void
     {
         $static = simplexml_load_string($xml);
         $static->registerXPathNamespace('sm', 'http://www.sitemaps.org/schemas/sitemap/0.9');
@@ -33,7 +33,7 @@ abstract class SitemapTestCase extends WebTestCase
         self::assertUrlConcrete($yaml, 'static', 0.5, 'daily');
     }
 
-    protected static function assertBlogSection(string $xml)
+    protected static function assertBlogSection(string $xml): void
     {
         $blog = simplexml_load_string($xml);
         $blog->registerXPathNamespace('sm', 'http://www.sitemaps.org/schemas/sitemap/0.9');
@@ -55,7 +55,7 @@ abstract class SitemapTestCase extends WebTestCase
         self::assertUrlHasVideo($postWithMultimedia, 'blog', 'https://www.youtube.com/watch?v=JugaMuswrmk');
     }
 
-    protected static function assertArchivesSection(string $xml)
+    protected static function assertArchivesSection(string $xml): void
     {
         $archives = simplexml_load_string($xml);
         $archives->registerXPathNamespace('sm', 'http://www.sitemaps.org/schemas/sitemap/0.9');
@@ -92,7 +92,7 @@ abstract class SitemapTestCase extends WebTestCase
         return reset($section);
     }
 
-    private static function assertSectionContainsCountUrls(SimpleXMLElement $xml, string $section, int $count)
+    private static function assertSectionContainsCountUrls(SimpleXMLElement $xml, string $section, int $count): void
     {
         Assert::assertCount(
             $count,
@@ -124,7 +124,7 @@ abstract class SitemapTestCase extends WebTestCase
         string $section,
         float $priority,
         string $changefreq
-    ) {
+    ): void {
         $loc = (string)$url->loc;
         $locationMessage = 'Sitemap URL "' . $loc . '" of section "' . $section . '"';
         Assert::assertInstanceOf(
@@ -144,7 +144,7 @@ abstract class SitemapTestCase extends WebTestCase
         );
     }
 
-    private static function assertUrlHasImage(SimpleXMLElement $url, string $section, string $loc)
+    private static function assertUrlHasImage(SimpleXMLElement $url, string $section, string $loc): void
     {
         $urlLoc = (string)$url->loc;
         Assert::assertCount(
@@ -156,7 +156,7 @@ abstract class SitemapTestCase extends WebTestCase
         );
     }
 
-    private static function assertUrlHasVideo(SimpleXMLElement $url, string $section, string $loc)
+    private static function assertUrlHasVideo(SimpleXMLElement $url, string $section, string $loc): void
     {
         $urlLoc = (string)$url->loc;
         Assert::assertCount(

--- a/Tests/Unit/Command/DumpSitemapsCommandTest.php
+++ b/Tests/Unit/Command/DumpSitemapsCommandTest.php
@@ -46,7 +46,7 @@ class DumpSitemapsCommandTest extends TestCase
     /**
      * @dataProvider dump
      */
-    public function testDumpSitemapSuccessful(?string $section, bool $gzip)
+    public function testDumpSitemapSuccessful(?string $section, bool $gzip): void
     {
         if ($section === null) {
             $files = ['sitemap.audio.xml', 'sitemap.video.xml'];
@@ -69,7 +69,7 @@ class DumpSitemapsCommandTest extends TestCase
     /**
      * @dataProvider dump
      */
-    public function testDumpSitemapFailed(?string $section, bool $gzip)
+    public function testDumpSitemapFailed(?string $section, bool $gzip): void
     {
         $this->dumper->dump(self::TARGET_DIR, self::BASE_URL, $section, ['gzip' => $gzip])
             ->shouldBeCalledTimes(1)

--- a/Tests/Unit/Controller/SitemapControllerTest.php
+++ b/Tests/Unit/Controller/SitemapControllerTest.php
@@ -18,6 +18,7 @@ use Presta\SitemapBundle\Sitemap\Sitemapindex;
 use Presta\SitemapBundle\Sitemap\Urlset;
 use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class SitemapControllerTest extends TestCase
 {
@@ -33,7 +34,7 @@ class SitemapControllerTest extends TestCase
         $this->generator = $this->prophesize(GeneratorInterface::class);
     }
 
-    public function testIndexSuccesful()
+    public function testIndexSuccessful(): void
     {
         /** @var Sitemapindex|ObjectProphecy $index */
         $index = $this->prophesize(Sitemapindex::class);
@@ -49,11 +50,10 @@ class SitemapControllerTest extends TestCase
         self::assertSitemapResponse($response, '<index/>');
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     */
-    public function testIndexNotFound()
+    public function testIndexNotFound(): void
     {
+        $this->expectException(NotFoundHttpException::class);
+
         $this->generator->fetch('root')
             ->shouldBeCalledTimes(1)
             ->willReturn(null);
@@ -61,7 +61,7 @@ class SitemapControllerTest extends TestCase
         $this->controller()->indexAction();
     }
 
-    public function testSectionSuccessful()
+    public function testSectionSuccessful(): void
     {
         /** @var Urlset|ObjectProphecy $urlset */
         $urlset = $this->prophesize(Urlset::class);
@@ -77,11 +77,10 @@ class SitemapControllerTest extends TestCase
         self::assertSitemapResponse($response, '<urlset/>');
     }
 
-    /**
-     * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     */
-    public function testSectionNotFound()
+    public function testSectionNotFound(): void
     {
+        $this->expectException(NotFoundHttpException::class);
+
         $this->generator->fetch('void')
             ->shouldBeCalledTimes(1)
             ->willReturn(null);
@@ -89,7 +88,7 @@ class SitemapControllerTest extends TestCase
         $this->controller()->sectionAction('void');
     }
 
-    private static function assertSitemapResponse($response, string $xml)
+    private static function assertSitemapResponse($response, string $xml): void
     {
         /** @var Response $response */
         self::assertInstanceOf(Response::class, $response,
@@ -98,11 +97,14 @@ class SitemapControllerTest extends TestCase
         self::assertEquals('text/xml', $response->headers->get('Content-Type'),
             'Controller returned an XML response'
         );
-        self::assertSame(true, $response->isCacheable(),
+        self::assertTrue($response->isCacheable(),
             'Controller returned a cacheable response'
         );
         self::assertSame(self::TTL, $response->getMaxAge(),
             'Controller returned a response cacheable for ' . self::TTL . ' seconds'
+        );
+        self::assertSame($xml, $response->getContent(),
+            'Controller returned expected content'
         );
     }
 

--- a/Tests/Unit/DependencyInjection/PrestaSitemapExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/PrestaSitemapExtensionTest.php
@@ -38,7 +38,7 @@ class PrestaSitemapExtensionTest extends TestCase
         ['presta_sitemap.defaults', self::DEFAULTS, 'Sitemap items default options'],
     ];
 
-    public function testLoadWithoutConfig()
+    public function testLoadWithoutConfig(): void
     {
         $container = new ContainerBuilder();
         $extension = new PrestaSitemapExtension();

--- a/Tests/Unit/EventListener/RouteAnnotationEventListenerTest.php
+++ b/Tests/Unit/EventListener/RouteAnnotationEventListenerTest.php
@@ -11,8 +11,11 @@
 
 namespace Presta\SitemapBundle\Tests\Unit\EventListener;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Presta\SitemapBundle\EventListener\RouteAnnotationEventListener;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouterInterface;
 
 /**
 * Manage sitemaps listing
@@ -24,24 +27,25 @@ class RouteAnnotationEventListenerTest extends TestCase
     /**
      * test no "sitemap" annotation
      */
-    public function testNoAnnotation()
+    public function testNoAnnotation(): void
     {
         self::assertEquals(null, $this->getListener()->getOptions('route1', $this->getRoute(null)), 'sitemap = null returns null');
     }
 
     /**
      * test "sitemap"="anything" annotation
-     * @expectedException \InvalidArgumentException
      */
-    public function testInvalidSitemapArbitrary()
+    public function testInvalidSitemapArbitrary(): void
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         self::assertEquals(-1, $this->getListener()->getOptions('route1', $this->getRoute('anything')), 'sitemap = "anything" throws an exception');
     }
 
     /**
      * test "sitemap"=false annotation
      */
-    public function testSitemapFalse()
+    public function testSitemapFalse(): void
     {
         self::assertNull($this->getListener()->getOptions('route1', $this->getRoute(false)), 'sitemap = false returns null');
     }
@@ -49,9 +53,9 @@ class RouteAnnotationEventListenerTest extends TestCase
     /**
      * test "sitemap"=true
      */
-    public function testDefaultAnnotation()
+    public function testDefaultAnnotation(): void
     {
-        $result=$this->getListener()->getOptions('route1', $this->getRoute(true));
+        $result = $this->getListener()->getOptions('route1', $this->getRoute(true));
         self::assertArrayHasKey('priority', $result);
         self::assertArrayHasKey('changefreq', $result);
         self::assertArrayHasKey('lastmod', $result);
@@ -63,72 +67,69 @@ class RouteAnnotationEventListenerTest extends TestCase
     /**
      * test "sitemap = {"priority" = "0.5"}
      */
-    public function testValidPriority()
+    public function testValidPriority(): void
     {
-        $result=$this->getListener()->getOptions('route1', $this->getRoute(['priority' => 0.5]));
+        $result = $this->getListener()->getOptions('route1', $this->getRoute(['priority' => 0.5]));
         self::assertEquals(0.5, $result['priority']);
     }
 
     /**
      * test "sitemap = {"changefreq = weekly"}
      */
-    public function testValidChangefreq()
+    public function testValidChangefreq(): void
     {
-        $result=$this->getListener()->getOptions('route1', $this->getRoute(['changefreq' => 'weekly']));
+        $result = $this->getListener()->getOptions('route1', $this->getRoute(['changefreq' => 'weekly']));
         self::assertEquals('weekly', $result['changefreq']);
     }
 
     /**
      * test "sitemap = {"lastmod" = "2012-01-01 00:00:00"}
      */
-    public function testValidLastmod()
+    public function testValidLastmod(): void
     {
-        $result=$this->getListener()->getOptions('route1', $this->getRoute(['lastmod' => '2012-01-01 00:00:00']));
+        $result = $this->getListener()->getOptions('route1', $this->getRoute(['lastmod' => '2012-01-01 00:00:00']));
         self::assertEquals(new \DateTime('2012-01-01 00:00:00'), $result['lastmod']);
     }
 
     /**
      * test "sitemap = {"lastmod" = "unknown"}
-     * @expectedException \InvalidArgumentException
      */
-    public function testInvalidLastmod()
+    public function testInvalidLastmod(): void
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $this->getListener()->getOptions('route1', $this->getRoute(['lastmod' => 'unknown']));
     }
 
     /**
-     * @param  null                             $option
-     * @return \Symfony\Component\Routing\Route
+     * @param null $option
+     *
+     * @return Route|MockObject
      */
     private function getRoute($option = null)
     {
-        $route = $this->getMockBuilder('Symfony\Component\Routing\Route')
+        $route = $this->getMockBuilder(Route::class)
             ->setMethods(['getOption'])
             ->disableOriginalConstructor()
             ->getMock();
 
-        $route->expects($this->once())
+        $route->expects(self::once())
             ->method('getOption')
-            ->will($this->returnValue($option));
+            ->willReturn($option);
 
         return $route;
     }
 
-    /**
-     * @return \Symfony\Component\Routing\RouterInterface
-     */
-    private function getRouter()
+    private function getRouter(): RouterInterface
     {
-        $router = $this->getMockBuilder('Symfony\Component\Routing\RouterInterface')
-        ->getMock();
+        /** @var RouterInterface|MockObject $router */
+        $router = $this->getMockBuilder(RouterInterface::class)
+            ->getMock();
 
         return $router;
     }
 
-    /**
-     * @return RouteAnnotationEventListener
-     */
-    private function getListener()
+    private function getListener(): RouteAnnotationEventListener
     {
         return new RouteAnnotationEventListener(
             $this->getRouter(),

--- a/Tests/Unit/Messenger/DumpSitemapMessageHandlerTest.php
+++ b/Tests/Unit/Messenger/DumpSitemapMessageHandlerTest.php
@@ -42,7 +42,7 @@ class DumpSitemapMessageHandlerTest extends TestCase
     protected function setUp(): void
     {
         if (!interface_exists(MessageBusInterface::class)) {
-            $this->markTestSkipped('Skipping messenger tests, because it is not installed.');
+            self::markTestSkipped('Skipping messenger tests, because it is not installed.');
 
             return;
         }

--- a/Tests/Unit/Service/GeneratorTest.php
+++ b/Tests/Unit/Service/GeneratorTest.php
@@ -51,13 +51,13 @@ class GeneratorTest extends WebTestCase
         });
     }
 
-    public function testGenerate()
+    public function testGenerate(): void
     {
         $this->generator()->generate();
         self::assertTrue(true, 'No exception was thrown');
     }
 
-    public function testFetch()
+    public function testFetch(): void
     {
         $generator = $this->generator();
 
@@ -75,21 +75,21 @@ class GeneratorTest extends WebTestCase
         self::assertTrue($triggered, 'Event listener was triggered');
     }
 
-    public function testAddUrl()
+    public function testAddUrl(): void
     {
         $url = $this->acmeHome();
         $this->generator()->addUrl($url, 'default');
         self::assertTrue(true, 'No exception was thrown');
     }
 
-    public function testGetUrlset()
+    public function testGetUrlset(): void
     {
         $urlset = $this->generator()->getUrlset('default');
 
         self::assertInstanceOf(Urlset::class, $urlset);
     }
 
-    public function testItemsBySet()
+    public function testItemsBySet(): void
     {
         $url = $this->acmeHome();
         $generator = $this->generator();
@@ -104,7 +104,7 @@ class GeneratorTest extends WebTestCase
         self::assertEquals(count($emptyUrlset), 0);
     }
 
-    public function testDefaults()
+    public function testDefaults(): void
     {
         $url = $this->acmeHome();
         $generator = $this->generator();
@@ -127,7 +127,7 @@ class GeneratorTest extends WebTestCase
         self::assertInstanceOf('DateTimeInterface', $url->getLastmod());
     }
 
-    public function testNullableDefaults()
+    public function testNullableDefaults(): void
     {
         $url = $this->acmeHome();
         $generator = $this->generator();

--- a/Tests/Unit/Sitemap/SitemapindexTest.php
+++ b/Tests/Unit/Sitemap/SitemapindexTest.php
@@ -21,7 +21,7 @@ use Presta\SitemapBundle\Sitemap;
  */
 class SitemapindexTest extends TestCase
 {
-    public function testAddSitemap()
+    public function testAddSitemap(): void
     {
         $sitemapindex = new Sitemap\Sitemapindex();
 
@@ -34,9 +34,9 @@ class SitemapindexTest extends TestCase
         self::assertFalse($failed, 'An exception must not be thrown');
     }
 
-    public function testGetSitemapXml()
+    public function testGetSitemapXml(): void
     {
-        $today          = new \DateTime;
+        $today          = new \DateTime();
         $loc            = 'http://acme.com/';
         $sitemapindex   = new Sitemap\Sitemapindex();
 
@@ -49,9 +49,9 @@ class SitemapindexTest extends TestCase
         );
     }
 
-    public function testToXml()
+    public function testToXml(): void
     {
-        $sitemapindex   = new Sitemap\Sitemapindex();
+        $sitemapindex = new Sitemap\Sitemapindex();
         $xml = $sitemapindex->toXml();
         self::assertXmlStringEqualsXmlString(
             '<?xml version="1.0" encoding="UTF-8"?><sitemapindex xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></sitemapindex>',
@@ -62,11 +62,10 @@ class SitemapindexTest extends TestCase
     /**
      * get accessible method that was private or protected
      *
-     * @param mixed $obj - classname or instance
-     * @param type $name
-     * @return \ReflectionMethod
+     * @param mixed  $obj - classname or instance
+     * @param string $name
      */
-    protected static function getMethod($obj, $name)
+    protected static function getMethod($obj, $name): \ReflectionMethod
     {
         $method = new \ReflectionMethod($obj, $name);
         $method->setAccessible(true);

--- a/Tests/Unit/Sitemap/Url/GoogleImageTest.php
+++ b/Tests/Unit/Sitemap/Url/GoogleImageTest.php
@@ -22,7 +22,7 @@ class GoogleImageTest extends TestCase
     /**
      * @dataProvider toXmlProvider
      */
-    public function testToXml($expectedXml, $loc, $caption = null, $geoLocalisation = null, $title = null, $license = null)
+    public function testToXml($expectedXml, $loc, $caption = null, $geoLocalisation = null, $title = null, $license = null): void
     {
         $failed = false;
         try {
@@ -35,7 +35,7 @@ class GoogleImageTest extends TestCase
         self::assertEquals($expectedXml, $image->toXML());
     }
 
-    public function toXmlProvider()
+    public function toXmlProvider(): array
     {
         return [
             [

--- a/Tests/Unit/Sitemap/Url/GoogleImageUrlDecoratorTest.php
+++ b/Tests/Unit/Sitemap/Url/GoogleImageUrlDecoratorTest.php
@@ -19,7 +19,7 @@ use Presta\SitemapBundle\Sitemap;
  */
 class GoogleImageUrlDecoratorTest extends TestCase
 {
-    public function testAddImage()
+    public function testAddImage(): void
     {
         $url = new Sitemap\Url\GoogleImageUrlDecorator(new Sitemap\Url\UrlConcrete('http://acme.com'));
 
@@ -33,13 +33,13 @@ class GoogleImageUrlDecoratorTest extends TestCase
         self::assertFalse($failed, 'An exception must not be thrown');
     }
 
-    public function testIsFull()
+    public function testIsFull(): void
     {
         $url = new Sitemap\Url\GoogleImageUrlDecorator(new Sitemap\Url\UrlConcrete('http://acme.com'));
         self::assertFalse($url->isFull());
     }
 
-    public function testToXml()
+    public function testToXml(): void
     {
         $url = new Sitemap\Url\GoogleImageUrlDecorator(new Sitemap\Url\UrlConcrete('http://acme.com'));
 

--- a/Tests/Unit/Sitemap/Url/GoogleMobileUrlDecoratorTest.php
+++ b/Tests/Unit/Sitemap/Url/GoogleMobileUrlDecoratorTest.php
@@ -19,7 +19,7 @@ use Presta\SitemapBundle\Sitemap;
  */
 class GoogleMobileUrlDecoratorTest extends TestCase
 {
-    public function testToXml()
+    public function testToXml(): void
     {
         $url = new Sitemap\Url\GoogleMobileUrlDecorator(new Sitemap\Url\UrlConcrete('http://m.acme.com'));
 

--- a/Tests/Unit/Sitemap/Url/GoogleMultilangUrlDecoratorTest.php
+++ b/Tests/Unit/Sitemap/Url/GoogleMultilangUrlDecoratorTest.php
@@ -19,7 +19,7 @@ use Presta\SitemapBundle\Sitemap;
  */
 class GoogleMultilangUrlDecoratorTest extends TestCase
 {
-    public function testAddLink()
+    public function testAddLink(): void
     {
         $url = new Sitemap\Url\GoogleMultilangUrlDecorator(new Sitemap\Url\UrlConcrete('http://acme.com'));
 

--- a/Tests/Unit/Sitemap/Url/GoogleNewsUrlDecoratorTest.php
+++ b/Tests/Unit/Sitemap/Url/GoogleNewsUrlDecoratorTest.php
@@ -11,12 +11,15 @@
 
 namespace Presta\SitemapBundle\Tests\Unit\Sitemap\Url;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Presta\SitemapBundle\Exception\GoogleNewsUrlException;
 use Presta\SitemapBundle\Service\Generator;
 use Presta\SitemapBundle\Sitemap\Url\GoogleNewsUrlDecorator;
 use Presta\SitemapBundle\Sitemap\Url\Url;
 use Presta\SitemapBundle\Sitemap\Url\UrlConcrete;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Routing\RouterInterface;
 
 /**
  * Tests the GoogleNewsUrlDecorator
@@ -28,7 +31,7 @@ class GoogleNewsUrlDecoratorTest extends TestCase
     /**
      * Tests if the news specific tags can be found.
      */
-    public function testCountNamespaces()
+    public function testCountNamespaces(): void
     {
         $url = $this->createExampleUrl();
         $dom = new \DOMDocument();
@@ -42,7 +45,7 @@ class GoogleNewsUrlDecoratorTest extends TestCase
     /**
      * Tests the default W3C format.
      */
-    public function testDefaultDateFormat()
+    public function testDefaultDateFormat(): void
     {
         $date = new \DateTime('2013-11-05 10:30:55');
 
@@ -60,7 +63,7 @@ class GoogleNewsUrlDecoratorTest extends TestCase
     /**
      * Test the custom date only format property.
      */
-    public function testCustomDateFormat()
+    public function testCustomDateFormat(): void
     {
         $date = new \DateTime('2013-11-05 10:30:55');
 
@@ -79,7 +82,7 @@ class GoogleNewsUrlDecoratorTest extends TestCase
     /**
      * Tests if the news access property is validated properly.
      */
-    public function testAccessPropertyValidation()
+    public function testAccessPropertyValidation(): void
     {
         $url = $this->createExampleUrl();
 
@@ -109,7 +112,7 @@ class GoogleNewsUrlDecoratorTest extends TestCase
     /**
      * Tests if the news geo location property is validated properly.
      */
-    public function testGeoLocationPropertyValidation()
+    public function testGeoLocationPropertyValidation(): void
     {
         $url = $this->createExampleUrl();
 
@@ -140,7 +143,7 @@ class GoogleNewsUrlDecoratorTest extends TestCase
     /**
      * Tests the limitation of the stock tickers
      */
-    public function testStockTickersLimit()
+    public function testStockTickersLimit(): void
     {
         $url = $this->createExampleUrl();
 
@@ -200,36 +203,29 @@ class GoogleNewsUrlDecoratorTest extends TestCase
 
     /**
      * Creates an example URL instance for the tests.
-     *
-     * @return GoogleNewsUrlDecorator
      */
-    private function createExampleUrl()
+    private function createExampleUrl(): GoogleNewsUrlDecorator
     {
-        $url = new GoogleNewsUrlDecorator(
+        return new GoogleNewsUrlDecorator(
             new UrlConcrete('http://acme.com/'),
             'The Example Times',
             'en',
             new \DateTime(),
             'An example news article'
         );
-
-        return $url;
     }
 
     /**
      * Generates the urlset XML for a given URL.
-     *
-     * @param Url $url
-     *
-     * @return string The rendered XML
      */
-    private function generateXml(Url $url)
+    private function generateXml(Url $url): string
     {
         $section = 'default';
-        $generator = new Generator(
-            $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock(),
-            $this->getMockBuilder('Symfony\Component\Routing\RouterInterface')->getMock()
-        );
+        /** @var EventDispatcherInterface|MockObject $eventDispatcher */
+        $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->getMock();
+        /** @var RouterInterface|MockObject $router */
+        $router = $this->getMockBuilder(RouterInterface::class)->getMock();
+        $generator = new Generator($eventDispatcher, $router);
         $generator->addUrl($url, 'default');
 
         return $generator->fetch($section)->toXml();

--- a/Tests/Unit/Sitemap/Url/GoogleVideoUrlDecoratorTest.php
+++ b/Tests/Unit/Sitemap/Url/GoogleVideoUrlDecoratorTest.php
@@ -28,7 +28,7 @@ class GoogleVideoUrlDecoratorTest extends TestCase
      */
     protected $xml;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $url = new GoogleVideoUrlDecorator(new UrlConcrete('http://acme.com/'));
         for ($i=1; $i <=3; $i++) {
@@ -66,7 +66,7 @@ class GoogleVideoUrlDecoratorTest extends TestCase
             $url->addVideo($video);
         }
 
-        $this->xml = new \DOMDocument;
+        $this->xml = new \DOMDocument();
 
         $xml = '<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"';
 
@@ -79,19 +79,19 @@ class GoogleVideoUrlDecoratorTest extends TestCase
         $this->xml->loadXML($xml);
     }
 
-    public function testCountNamespaces()
+    public function testCountNamespaces(): void
     {
         $namespaces = $this->xml->getElementsByTagNameNS('http://www.google.com/schemas/sitemap-video/1.1', '*');
         self::assertEquals(72, $namespaces->length);
     }
 
-    public function testEncodeUrl()
+    public function testEncodeUrl(): void
     {
         $playerLoc = $this->xml->getElementsByTagName('player_loc')->item(0)->nodeValue;
         self::assertEquals($playerLoc, 'http://acme.com/video/player.swf?a=b&c=d');
     }
 
-    public function testRenderCategory()
+    public function testRenderCategory(): void
     {
         $category = $this->xml->getElementsByTagName('category')->item(0)->nodeValue;
         self::assertEquals($category, 'Testing w/ spécial chars');
@@ -124,21 +124,21 @@ class GoogleVideoUrlDecoratorTest extends TestCase
         $xpath->registerNamespace('s', 'http://www.sitemaps.org/schemas/sitemap/0.9');
         $xpath->registerNamespace('v', 'http://www.google.com/schemas/sitemap-video/1.1');
 
-        $this->assertEquals('http://acme.com/video/thumbnail1.jpg', $xpath->evaluate('string(/s:urlset/s:url/v:video[1]/v:thumbnail_loc)'));
-        $this->assertEquals('http://acme.com/video/thumbnail2.jpg', $xpath->evaluate('string(/s:urlset/s:url/v:video[2]/v:thumbnail_loc)'));
-        $this->assertEquals('http://acme.com/video/thumbnail3.jpg', $xpath->evaluate('string(/s:urlset/s:url/v:video[3]/v:thumbnail_loc)'));
+        self::assertEquals('http://acme.com/video/thumbnail1.jpg', $xpath->evaluate('string(/s:urlset/s:url/v:video[1]/v:thumbnail_loc)'));
+        self::assertEquals('http://acme.com/video/thumbnail2.jpg', $xpath->evaluate('string(/s:urlset/s:url/v:video[2]/v:thumbnail_loc)'));
+        self::assertEquals('http://acme.com/video/thumbnail3.jpg', $xpath->evaluate('string(/s:urlset/s:url/v:video[3]/v:thumbnail_loc)'));
 
-        $this->assertEquals('Acme video 1', $xpath->evaluate('string(/s:urlset/s:url/v:video[1]/v:title)'));
-        $this->assertEquals('Acme video 2', $xpath->evaluate('string(/s:urlset/s:url/v:video[2]/v:title)'));
-        $this->assertEquals('Acme video 3', $xpath->evaluate('string(/s:urlset/s:url/v:video[3]/v:title)'));
+        self::assertEquals('Acme video 1', $xpath->evaluate('string(/s:urlset/s:url/v:video[1]/v:title)'));
+        self::assertEquals('Acme video 2', $xpath->evaluate('string(/s:urlset/s:url/v:video[2]/v:title)'));
+        self::assertEquals('Acme video 3', $xpath->evaluate('string(/s:urlset/s:url/v:video[3]/v:title)'));
 
-        $this->assertEquals('An acme video for testing purposes (1)', $xpath->evaluate('string(/s:urlset/s:url/v:video[1]/v:description)'));
-        $this->assertEquals('An acme video for testing purposes (2)', $xpath->evaluate('string(/s:urlset/s:url/v:video[2]/v:description)'));
-        $this->assertEquals('An acme video for testing purposes (3)', $xpath->evaluate('string(/s:urlset/s:url/v:video[3]/v:description)'));
+        self::assertEquals('An acme video for testing purposes (1)', $xpath->evaluate('string(/s:urlset/s:url/v:video[1]/v:description)'));
+        self::assertEquals('An acme video for testing purposes (2)', $xpath->evaluate('string(/s:urlset/s:url/v:video[2]/v:description)'));
+        self::assertEquals('An acme video for testing purposes (3)', $xpath->evaluate('string(/s:urlset/s:url/v:video[3]/v:description)'));
 
-        $this->assertEquals('http://acme.com/video/content1.flv', $xpath->evaluate('string(/s:urlset/s:url/v:video[1]/v:content_loc)'));
-        $this->assertEquals('http://acme.com/video/content2.flv', $xpath->evaluate('string(/s:urlset/s:url/v:video[2]/v:content_loc)'));
-        $this->assertEquals('http://acme.com/video/content3.flv', $xpath->evaluate('string(/s:urlset/s:url/v:video[3]/v:content_loc)'));
+        self::assertEquals('http://acme.com/video/content1.flv', $xpath->evaluate('string(/s:urlset/s:url/v:video[1]/v:content_loc)'));
+        self::assertEquals('http://acme.com/video/content2.flv', $xpath->evaluate('string(/s:urlset/s:url/v:video[2]/v:content_loc)'));
+        self::assertEquals('http://acme.com/video/content3.flv', $xpath->evaluate('string(/s:urlset/s:url/v:video[3]/v:content_loc)'));
     }
 
     private function setUpLegacy(): void
@@ -176,7 +176,7 @@ class GoogleVideoUrlDecoratorTest extends TestCase
         $url->addPrice(42, 'EUR', GoogleVideoUrlDecorator::PRICE_TYPE_OWN, GoogleVideoUrlDecorator::PRICE_RESOLUTION_HD);
         $url->addPrice(53, 'USD');
 
-        $this->xml = new \DOMDocument;
+        $this->xml = new \DOMDocument();
 
         $xml = '<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"';
 
@@ -192,7 +192,7 @@ class GoogleVideoUrlDecoratorTest extends TestCase
     /**
      * @group legacy
      */
-    public function testCountNamespacesLegacy()
+    public function testCountNamespacesLegacy(): void
     {
         $this->setUpLegacy();
 
@@ -203,7 +203,7 @@ class GoogleVideoUrlDecoratorTest extends TestCase
     /**
      * @group legacy
      */
-    public function testEncodeUrlLegacy()
+    public function testEncodeUrlLegacy(): void
     {
         $this->setUpLegacy();
 
@@ -214,7 +214,7 @@ class GoogleVideoUrlDecoratorTest extends TestCase
     /**
      * @group legacy
      */
-    public function testRenderCategoryLegacy()
+    public function testRenderCategoryLegacy(): void
     {
         $this->setUpLegacy();
 

--- a/Tests/Unit/Sitemap/Url/UrlConcreteTest.php
+++ b/Tests/Unit/Sitemap/Url/UrlConcreteTest.php
@@ -22,13 +22,13 @@ class UrlConcreteTest extends TestCase
     /**
      * @dataProvider toXmlProvider
      */
-    public function testToXml($expectedXml, $loc, $lastmod = null, $changefreq = null, $priority = null)
+    public function testToXml($expectedXml, $loc, $lastmod = null, $changefreq = null, $priority = null): void
     {
         $url = new UrlConcrete($loc, $lastmod, $changefreq, $priority);
         self::assertEquals($expectedXml, $url->toXml());
     }
 
-    public function toXmlProvider()
+    public function toXmlProvider(): array
     {
         return [
             ['<url><loc>http://example.com/</loc></url>', 'http://example.com/'],
@@ -116,7 +116,7 @@ class UrlConcreteTest extends TestCase
     /**
      * @dataProvider setPriorityProvider
      */
-    public function testSetPriority($assigned, ?float $expected)
+    public function testSetPriority($assigned, ?float $expected): void
     {
         $url = new UrlConcrete('http://example.com');
         $url->setPriority($assigned);

--- a/Tests/Unit/Sitemap/UrlsetTest.php
+++ b/Tests/Unit/Sitemap/UrlsetTest.php
@@ -21,12 +21,12 @@ class UrlsetTest extends TestCase
 {
     protected $urlset;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->urlset = new Sitemap\Urlset('http://acme.com/sitemap.default.xml');
     }
 
-    public function testAddUrl()
+    public function testAddUrl(): void
     {
         $failed = false;
         try {
@@ -38,11 +38,11 @@ class UrlsetTest extends TestCase
         self::assertFalse($failed, 'An exception must not be thrown');
     }
 
-    public function testToXml()
+    public function testToXml(): void
     {
         $this->urlset->addUrl(new Sitemap\Url\UrlConcrete('http://acme.com/'));
 
-        $xml = new \DOMDocument;
+        $xml = new \DOMDocument();
         $xml->loadXML($this->urlset->toXml());
 
         self::assertEquals(1, $xml->getElementsByTagName('url')->length);

--- a/Tests/Unit/Sitemap/UtilsTest.php
+++ b/Tests/Unit/Sitemap/UtilsTest.php
@@ -22,40 +22,35 @@ use Presta\SitemapBundle\Sitemap\Utils;
  */
 class UtilsTest extends TestCase
 {
-
-    /**
-     * @expectedException Exception
-     */
-    public function testGetSetMethodException()
+    public function testGetSetMethodException(): void
     {
+        $this->expectException(Exception::class);
+
         $object = new \stdClass();
         Utils::getSetMethod($object, 'unknown');
     }
 
-    /**
-     * @expectedException Exception
-     */
-    public function testGetGetMethodException()
+    public function testGetGetMethodException(): void
     {
+        $this->expectException(Exception::class);
+
         $object = new \stdClass();
         Utils::getGetMethod($object, 'unknown');
     }
 
-
-    public function testRender()
+    public function testRender(): void
     {
         $actual = Utils::render('data w/ cdata section');
         self::assertEquals('<![CDATA[data w/ cdata section]]>', $actual);
     }
 
-    public function testEncode()
+    public function testEncode(): void
     {
         $actual = Utils::encode('data & spécial chars>');
         self::assertEquals('data &amp; spécial chars&gt;', $actual);
     }
 
-
-    public function testCamelize()
+    public function testCamelize(): void
     {
         $actual = Utils::camelize('data to_camelize');
         self::assertEquals('DataToCamelize', $actual);


### PR DESCRIPTION
- Add return `void` where applicable
- Remove unused imports
- Use `self::` instead of `$this->` where applicable for consistency
` Use `$this->expectException` instead of deprecated `@expectedException` annotation
- Remove useless phpdocs where argument typehints already declared