### PR TITLE
Increase code coverage by levearing new tests and refactoring some code

### DIFF
--- a/Controller/SitemapController.php
+++ b/Controller/SitemapController.php
@@ -91,9 +91,13 @@ class SitemapController
      * Time to live of the response in seconds
      *
      * @return int
+     * @deprecated since v2.3.0
+     * @codeCoverageIgnore
      */
     protected function getTtl()
     {
+        @trigger_error(__METHOD__ . ' method is deprecated since v2.3.0', E_USER_DEPRECATED);
+
         return $this->ttl;
     }
 }

--- a/Routing/RouteOptionParser.php
+++ b/Routing/RouteOptionParser.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Presta\SitemapBundle\Routing;
+
+use Symfony\Component\Routing\Route;
+
+final class RouteOptionParser
+{
+    public static function parse(string $name, Route $route): ?array
+    {
+        $option = $route->getOption('sitemap');
+
+        if ($option === null) {
+            return null;
+        }
+
+        if (\is_string($option)) {
+            if (!\function_exists('json_decode')) {
+                throw new \RuntimeException(
+                    \sprintf(
+                        'The route %s sitemap options are defined as JSON string, but PHP extension is missing.',
+                        $name
+                    )
+                );
+            }
+            $decoded = \json_decode($option, true);
+            if (!\json_last_error() && \is_array($decoded)) {
+                $option = $decoded;
+            }
+        }
+
+        if (!\is_array($option) && !\is_bool($option)) {
+            $bool = \filter_var($option, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+
+            if (null === $bool) {
+                throw new \InvalidArgumentException(
+                    \sprintf(
+                        'The route %s sitemap option must be of type "boolean" or "array", got "%s"',
+                        $name,
+                        $option
+                    )
+                );
+            }
+
+            $option = $bool;
+        }
+
+        if (!$option) {
+            return null;
+        }
+
+        $options = [
+            'section' => null,
+            'lastmod' => null,
+            'changefreq' => null,
+            'priority' => null,
+        ];
+        if (\is_array($option)) {
+            $options = \array_merge($options, $option);
+        }
+
+        if (\is_string($options['lastmod'])) {
+            try {
+                $options['lastmod'] = new \DateTimeImmutable($options['lastmod']);
+            } catch (\Exception $e) {
+                throw new \InvalidArgumentException(
+                    \sprintf(
+                        'The route %s has an invalid value "%s" specified for the "lastmod" option',
+                        $name,
+                        $options['lastmod']
+                    ),
+                    0,
+                    $e
+                );
+            }
+        }
+
+        return $options;
+    }
+}

--- a/Tests/Unit/InMemoryUrlContainer.php
+++ b/Tests/Unit/InMemoryUrlContainer.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Presta\SitemapBundle\Tests\Unit;
+
+use Presta\SitemapBundle\Service\UrlContainerInterface;
+use Presta\SitemapBundle\Sitemap\Url\Url;
+
+/**
+ * For tests purpose only !
+ * Add urls to internal instance var.
+ */
+final class InMemoryUrlContainer implements UrlContainerInterface
+{
+    /**
+     * @var Url[][]
+     */
+    private $urls = [];
+
+    public function addUrl(Url $url, $section)
+    {
+        $this->urls[$section][] = $url;
+    }
+
+    /**
+     * @param string $section
+     *
+     * @return Url[]
+     */
+    public function getUrlset(string $section): array
+    {
+        return $this->urls[$section] ?? [];
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getSections(): array
+    {
+        return \array_keys($this->urls);
+    }
+}

--- a/Tests/Unit/Routing/RouteOptionParserTest.php
+++ b/Tests/Unit/Routing/RouteOptionParserTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Presta\SitemapBundle\Tests\Unit\Routing;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Presta\SitemapBundle\Routing\RouteOptionParser;
+use Symfony\Component\Routing\Route;
+
+class RouteOptionParserTest extends TestCase
+{
+    public function testInvalidRouteOption(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        RouteOptionParser::parse('route1', $this->getRoute('anything'));
+    }
+
+    public function testInvalidLastmodRouteOption(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        RouteOptionParser::parse('route1', $this->getRoute(['lastmod' => 'unknown']));
+    }
+
+    /**
+     * @dataProvider notRegisteredOptions
+     */
+    public function testNotRegisteredOptions($option): void
+    {
+        $options = RouteOptionParser::parse('route_name', $this->getRoute($option));
+
+        self::assertNull($options, 'Not registered to sitemap');
+    }
+
+    /**
+     * @dataProvider registeredOptions
+     */
+    public function testRegisteredOptions(
+        $option,
+        ?string $section,
+        ?DateTimeImmutable $lastmod,
+        ?string $changefreq,
+        ?float $priority
+    ): void {
+        $options = RouteOptionParser::parse('route_name', $this->getRoute($option));
+
+        self::assertNotNull($options, 'Registered to sitemap');
+
+        self::assertArrayHasKey('section', $options, '"section" option is defined');
+        self::assertArrayHasKey('lastmod', $options, '"lastmod" option is defined');
+        self::assertArrayHasKey('changefreq', $options, '"changefreq" option is defined');
+        self::assertArrayHasKey('priority', $options, '"priority" option is defined');
+
+        self::assertSame($section, $options['section'], '"section" option is as expected');
+        self::assertEquals($lastmod, $options['lastmod'], '"lastmod" option is as expected');
+        self::assertSame($changefreq, $options['changefreq'], '"changefreq" option is as expected');
+        self::assertSame($priority, $options['priority'], '"priority" option is as expected');
+    }
+
+    public function notRegisteredOptions(): \Generator
+    {
+        yield [null];
+        yield [false];
+        yield ['no'];
+    }
+
+    public function registeredOptions(): \Generator
+    {
+        yield [true, null, null, null, null];
+        yield ['yes', null, null, null, null];
+        yield [['priority' => 0.5], null, null, null, 0.5];
+        yield [['changefreq' => 'weekly'], null, null, 'weekly', null];
+        yield [['lastmod' => '2012-01-01 00:00:00'], null, new \DateTimeImmutable('2012-01-01 00:00:00'), null, null];
+        yield [['section' => 'blog'], 'blog', null, null, null];
+    }
+
+    /**
+     * @param mixed $option
+     *
+     * @return Route|MockObject
+     */
+    private function getRoute($option): MockObject
+    {
+        $route = $this->getMockBuilder(Route::class)
+            ->setMethods(['getOption'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $route->expects($this->once())
+            ->method('getOption')
+            ->will($this->returnValue($option));
+
+        return $route;
+    }
+}


### PR DESCRIPTION
- Added more tests cases to DumpSitemapsCommand
- Mark SitemapController::getTtl as deprecated and ignored for coverage
- Add static class that extract infos from routing option and rewrite tests to cover listener
