### PR TITLE
Properties naming convention

### DIFF
--- a/Sitemap/Url/GoogleImage.php
+++ b/Sitemap/Url/GoogleImage.php
@@ -24,7 +24,7 @@ class GoogleImage
     /**
      * @var string
      */
-    protected $loc;
+    protected $location;
 
     /**
      * @var string|null
@@ -34,7 +34,7 @@ class GoogleImage
     /**
      * @var string|null
      */
-    protected $geo_location;
+    protected $geoLocation;
 
     /**
      * @var string|null
@@ -49,39 +49,94 @@ class GoogleImage
     /**
      * create a GoogleImage for your GoogleImageUrl
      *
-     * @param string      $loc
-     * @param string|null $caption      [optional]
-     * @param string|null $geo_location [optional]
-     * @param string|null $title        [optional]
-     * @param string|null $license      [optional]
+     * @param string      $location
+     * @param string|null $caption     [optional]
+     * @param string|null $geoLocation [optional]
+     * @param string|null $title       [optional]
+     * @param string|null $license     [optional]
      */
-    public function __construct($loc, $caption = null, $geo_location = null, $title = null, $license = null)
+    public function __construct($location, $caption = null, $geoLocation = null, $title = null, $license = null)
     {
-        $this->setLoc($loc);
+        $this->setLocation($location);
         $this->setCaption($caption);
-        $this->setGeoLocation($geo_location);
+        $this->setGeoLocation($geoLocation);
         $this->setTitle($title);
         $this->setLicense($license);
     }
 
+    public function __get(string $name)
+    {
+        $map = [
+            'loc' => 'location',
+            'geo_location' => 'geoLocation',
+        ];
+
+        if (array_key_exists($name, $map)) {
+            $newName = $map[$name];
+            @trigger_error(
+                sprintf('Property %s::$%s is deprecated since 2.3.0, use $%s instead.', __CLASS__, $name, $newName),
+                E_USER_DEPRECATED
+            );
+
+            return $this->{$newName};
+        }
+
+        trigger_error(sprintf('Undefined property: %s::$%s', __CLASS__, $name), E_NOTICE);
+
+        return null;
+    }
+
     /**
+     * @deprecated since 2.3.0, to be removed in 3.0.0
+     *
      * @param string $loc
      *
      * @return GoogleImage
      */
     public function setLoc($loc)
     {
-        $this->loc = $loc;
+        @trigger_error(
+            sprintf('Method %s is deprecated since 2.3.0, use %s::setLocation instead.', __METHOD__, __CLASS__),
+            E_USER_DEPRECATED
+        );
+        $this->setLocation($loc);
 
         return $this;
     }
 
     /**
+     * @param string $location
+     *
+     * @return GoogleImage
+     */
+    public function setLocation($location)
+    {
+        $this->location = $location;
+
+        return $this;
+    }
+
+    /**
+     * @deprecated since 2.3.0, to be removed in 3.0.0
+     *
      * @return string
      */
     public function getLoc()
     {
-        return $this->loc;
+        @trigger_error(
+            sprintf('Method %s is deprecated since 2.3.0, use %s::getLocation instead.', __METHOD__, __CLASS__),
+            E_USER_DEPRECATED
+        );
+
+        return $this->getLocation();
+    }
+
+    /**
+     * @return string
+     */
+    public function getLocation()
+    {
+        return $this->location;
     }
 
     /**
@@ -105,13 +160,13 @@ class GoogleImage
     }
 
     /**
-     * @param null|string $geo_location
+     * @param null|string $geoLocation
      *
      * @return GoogleImage
      */
-    public function setGeoLocation($geo_location)
+    public function setGeoLocation($geoLocation)
     {
-        $this->geo_location = $geo_location;
+        $this->geoLocation = $geoLocation;
 
         return $this;
     }
@@ -121,7 +176,7 @@ class GoogleImage
      */
     public function getGeoLocation()
     {
-        return $this->geo_location;
+        return $this->geoLocation;
     }
 
     /**
@@ -173,22 +228,22 @@ class GoogleImage
     {
         $xml = '<image:image>';
 
-        $xml .= '<image:loc>' . Utils::encode($this->getLoc()) . '</image:loc>';
+        $xml .= '<image:loc>' . Utils::encode($this->getLocation()) . '</image:loc>';
 
         if ($this->getCaption()) {
-            $xml .= '<image:caption>' . Utils::render($this->getCaption()) . '</image:caption>';
+            $xml .= '<image:caption>' . Utils::cdata($this->getCaption()) . '</image:caption>';
         }
 
         if ($this->getGeoLocation()) {
-            $xml .= '<image:geo_location>' . Utils::render($this->getGeoLocation()) . '</image:geo_location>';
+            $xml .= '<image:geo_location>' . Utils::cdata($this->getGeoLocation()) . '</image:geo_location>';
         }
 
         if ($this->getTitle()) {
-            $xml .= '<image:title>' . Utils::render($this->getTitle()) . '</image:title>';
+            $xml .= '<image:title>' . Utils::cdata($this->getTitle()) . '</image:title>';
         }
 
         if ($this->getLicense()) {
-            $xml .= '<image:license>' . Utils::render($this->getLicense()) . '</image:license>';
+            $xml .= '<image:license>' . Utils::cdata($this->getLicense()) . '</image:license>';
         }
 
         $xml .= '</image:image>';

--- a/Sitemap/Url/GoogleImage.php
+++ b/Sitemap/Url/GoogleImage.php
@@ -64,7 +64,7 @@ class GoogleImage
         $this->setLicense($license);
     }
 
-    public function __get(string $name)
+    public function __get($name)
     {
         $map = [
             'loc' => 'location',
@@ -86,7 +86,7 @@ class GoogleImage
         return null;
     }
 
-    public function __set(string $name, $value)
+    public function __set($name, $value)
     {
         $map = [
             'loc' => 'location',

--- a/Sitemap/Url/GoogleImage.php
+++ b/Sitemap/Url/GoogleImage.php
@@ -86,6 +86,28 @@ class GoogleImage
         return null;
     }
 
+    public function __set(string $name, $value)
+    {
+        $map = [
+            'loc' => 'location',
+            'geo_location' => 'geoLocation',
+        ];
+
+        if (array_key_exists($name, $map)) {
+            $newName = $map[$name];
+            @trigger_error(
+                sprintf('Property %s::$%s is deprecated since 2.3.0, use $%s instead.', __CLASS__, $name, $newName),
+                E_USER_DEPRECATED
+            );
+
+            $this->{$newName} = $value;
+
+            return;
+        }
+
+        trigger_error(sprintf('Undefined property: %s::$%s', __CLASS__, $name), E_NOTICE);
+    }
+
     /**
      * @deprecated since 2.3.0, to be removed in 3.0.0
      *

--- a/Sitemap/Url/GoogleNewsUrlDecorator.php
+++ b/Sitemap/Url/GoogleNewsUrlDecorator.php
@@ -104,16 +104,10 @@ class GoogleNewsUrlDecorator extends UrlDecorator
     ) {
         parent::__construct($urlDecorated);
 
-        $this->publicationName = $publicationName;
-        if (strlen($publicationLanguage) > 5) {
-            throw new Exception\GoogleNewsUrlException(
-                'Use a 2 oder 3 character long ISO 639 language code. Except for chinese use zh-cn or zh-tw.' .
-                'See https://support.google.com/webmasters/answer/74288?hl=en&ref_topic=10078'
-            );
-        }
-        $this->publicationLanguage = $publicationLanguage;
-        $this->publicationDate = $publicationDate;
-        $this->title = $title;
+        $this->setPublicationName($publicationName);
+        $this->setPublicationLanguage($publicationLanguage);
+        $this->setPublicationDate($publicationDate);
+        $this->setTitle($title);
     }
 
     /**
@@ -151,6 +145,12 @@ class GoogleNewsUrlDecorator extends UrlDecorator
      */
     public function setPublicationLanguage($publicationLanguage)
     {
+        if (strlen($publicationLanguage) > 5) {
+            throw new Exception\GoogleNewsUrlException(
+                'Use a 2 oder 3 character long ISO 639 language code. Except for chinese use zh-cn or zh-tw.' .
+                'See https://support.google.com/webmasters/answer/74288?hl=en&ref_topic=10078'
+            );
+        }
         $this->publicationLanguage = $publicationLanguage;
 
         return $this;
@@ -200,7 +200,10 @@ class GoogleNewsUrlDecorator extends UrlDecorator
      */
     public function setGenres(array $genres)
     {
-        $this->genres = $genres;
+        $this->genres = [];
+        foreach ($genres as $genre) {
+            $this->addGenre($genre);
+        }
 
         return $this;
     }
@@ -332,7 +335,10 @@ class GoogleNewsUrlDecorator extends UrlDecorator
      */
     public function setKeywords(array $keywords)
     {
-        $this->keywords = $keywords;
+        $this->keywords = [];
+        foreach ($keywords as $keyword) {
+            $this->addKeyword($keyword);
+        }
 
         return $this;
     }
@@ -401,7 +407,7 @@ class GoogleNewsUrlDecorator extends UrlDecorator
         $newsXml = '<news:news>';
 
         $newsXml .= '<news:publication>';
-        $newsXml .= '<news:name>' . Utils::render($this->getPublicationName()) . '</news:name>';
+        $newsXml .= '<news:name>' . Utils::cdata($this->getPublicationName()) . '</news:name>';
         $newsXml .= '<news:language>' . $this->getPublicationLanguage() . '</news:language>';
         $newsXml .= '</news:publication>';
 
@@ -417,7 +423,7 @@ class GoogleNewsUrlDecorator extends UrlDecorator
                 $this->getPublicationDateFormat()
             ) . '</news:publication_date>';
 
-        $newsXml .= '<news:title>' . Utils::render($this->getTitle()) . '</news:title>';
+        $newsXml .= '<news:title>' . Utils::cdata($this->getTitle()) . '</news:title>';
 
         if ($this->getGeoLocations()) {
             $newsXml .= '<news:geo_locations>' . $this->getGeoLocations() . '</news:geo_locations>';

--- a/Sitemap/Url/GoogleVideo.php
+++ b/Sitemap/Url/GoogleVideo.php
@@ -352,6 +352,42 @@ class GoogleVideo
         return null;
     }
 
+    public function __set(string $name, $value)
+    {
+        $map = [
+            'thumbnail_loc' => 'thumbnailLocation',
+            'content_loc' => 'contentLocation',
+            'player_loc' => 'playerLocation',
+            'player_loc_allow_embed' => 'playerLocationAllowEmbed',
+            'player_loc_autoplay' => 'playerLocationAutoplay',
+            'expiration_date' => 'expirationDate',
+            'view_count' => 'viewCount',
+            'publication_date' => 'publicationDate',
+            'family_friendly' => 'familyFriendly',
+            'restriction_allow' => 'restrictionAllow',
+            'restriction_deny' => 'restrictionDeny',
+            'gallery_loc' => 'galleryLocation',
+            'gallery_loc_title' => 'galleryLocationTitle',
+            'requires_subscription' => 'requiresSubscription',
+            'uploader_info' => 'uploaderInformation',
+            'platform_relationship' => 'platformRelationship',
+        ];
+
+        if (array_key_exists($name, $map)) {
+            $newName = $map[$name];
+            @trigger_error(
+                sprintf('Property %s::$%s is deprecated since 2.3.0, use $%s instead.', __CLASS__, $name, $newName),
+                E_USER_DEPRECATED
+            );
+
+            $this->{$newName} = $value;
+
+            return;
+        }
+
+        trigger_error(sprintf('Undefined property: %s::$%s', __CLASS__, $name), E_NOTICE);
+    }
+
     /**
      * @deprecated since 2.3.0, to be removed in 3.0.0
      *

--- a/Sitemap/Url/GoogleVideo.php
+++ b/Sitemap/Url/GoogleVideo.php
@@ -46,7 +46,7 @@ class GoogleVideo
     /**
      * @var string
      */
-    protected $thumbnail_loc;
+    protected $thumbnailLocation;
 
     /**
      * @var string
@@ -63,24 +63,24 @@ class GoogleVideo
     /**
      * @var string|null
      */
-    protected $content_loc;
+    protected $contentLocation;
 
     /**
      * @var string|null
      */
-    protected $player_loc;
+    protected $playerLocation;
 
     /**
      * allow google to embed video in search results
      * @var string
      */
-    protected $player_loc_allow_embed;
+    protected $playerLocationAllowEmbed;
 
     /**
      * user defined string for flashvar parameters in embed tag (e.g. autoplay="ap=1")
      * @var string
      */
-    protected $player_loc_autoplay;
+    protected $playerLocationAutoplay;
 
     /**
      * @var int|null
@@ -90,7 +90,7 @@ class GoogleVideo
     /**
      * @var DateTimeInterface|null
      */
-    protected $expiration_date;
+    protected $expirationDate;
 
     /**
      * @var int|null
@@ -100,17 +100,17 @@ class GoogleVideo
     /**
      * @var int|null
      */
-    protected $view_count;
+    protected $viewCount;
 
     /**
      * @var DateTimeInterface|null
      */
-    protected $publication_date;
+    protected $publicationDate;
 
     /**
      * @var string|null
      */
-    protected $family_friendly;
+    protected $familyFriendly;
 
     /**
      * @var string|null
@@ -120,27 +120,27 @@ class GoogleVideo
     /**
      * @var array
      */
-    protected $restriction_allow = [];
+    protected $restrictionAllow = [];
 
     /**
      * @var array
      */
-    protected $restriction_deny = [];
+    protected $restrictionDeny = [];
 
     /**
      * @var string|null
      */
-    protected $gallery_loc;
+    protected $galleryLocation;
 
     /**
      * @var string|null
      */
-    protected $gallery_loc_title;
+    protected $galleryLocationTitle;
 
     /**
      * @var string|null
      */
-    protected $requires_subscription;
+    protected $requiresSubscription;
 
     /**
      * @var string|null
@@ -150,7 +150,7 @@ class GoogleVideo
     /**
      * @var string|null
      */
-    protected $uploader_info;
+    protected $uploaderInfo;
 
     /**
      * @var array
@@ -160,7 +160,7 @@ class GoogleVideo
     /**
      * @var string|null
      */
-    protected $platform_relationship;
+    protected $platformRelationship;
 
     /**
      * @var string|null
@@ -182,54 +182,227 @@ class GoogleVideo
     /**
      * create a GoogleImage for your GoogleImageUrl
      *
-     * @param string $thumnail_loc
+     * @param string $thumbnailLocation
      * @param string $title
      * @param string $description
-     * @param array  $parameters - the keys to use are the optional properties of this class, (e.g. 'player_loc' =>
-     *                           'http://acme.com/player.swf')
+     * @param array  $parameters Properties of this class, (e.g. 'player_loc' => 'http://acme.com/player.swf')
      *
      * @throws Exception\GoogleVideoException
      */
-    public function __construct($thumnail_loc, $title, $description, array $parameters = [])
+    public function __construct($thumbnailLocation, $title, $description, array $parameters = [])
     {
         foreach ($parameters as $key => $param) {
-            $method = Utils::getSetMethod($this, $key);
-            $this->$method($param);
+            switch ($key) {
+                case 'content_loc':
+                    @trigger_error(
+                        'GoogleVideo parameter ' . $key . ' is deprecated since 2.3.0, use "content_location" parameter instead',
+                        E_USER_DEPRECATED
+                    );
+                    $this->setContentLocation($param);
+                    break;
+                case 'content_location':
+                    $this->setContentLocation($param);
+                    break;
+                case 'player_loc':
+                    @trigger_error(
+                        'GoogleVideo parameter ' . $key . ' is deprecated since 2.3.0, use "player_location" parameter instead',
+                        E_USER_DEPRECATED
+                    );
+                    $this->setPlayerLocation($param);
+                    break;
+                case 'player_location':
+                    $this->setPlayerLocation($param);
+                    break;
+                case 'player_loc_allow_embed':
+                    @trigger_error(
+                        'GoogleVideo parameter ' . $key . ' is deprecated since 2.3.0, use "player_location_allow_embed" parameter instead',
+                        E_USER_DEPRECATED
+                    );
+                    $this->setPlayerLocationAllowEmbed($param);
+                    break;
+                case 'player_location_allow_embed':
+                    $this->setPlayerLocationAllowEmbed($param);
+                    break;
+                case 'player_loc_autoplay':
+                    @trigger_error(
+                        'GoogleVideo parameter ' . $key . ' is deprecated since 2.3.0, use "player_location_autoplay" parameter instead',
+                        E_USER_DEPRECATED
+                    );
+                    $this->setPlayerLocationAutoplay($param);
+                    break;
+                case 'player_location_autoplay':
+                    $this->setPlayerLocationAutoplay($param);
+                    break;
+                case 'duration':
+                    $this->setDuration($param);
+                    break;
+                case 'expiration_date':
+                    $this->setExpirationDate($param);
+                    break;
+                case 'rating':
+                    $this->setRating($param);
+                    break;
+                case 'view_count':
+                    $this->setViewCount($param);
+                    break;
+                case 'publication_date':
+                    $this->setPublicationDate($param);
+                    break;
+                case 'family_friendly':
+                    $this->setFamilyFriendly($param);
+                    break;
+                case 'category':
+                    $this->setCategory($param);
+                    break;
+                case 'restriction_allow':
+                    $this->setRestrictionAllow($param);
+                    break;
+                case 'restriction_deny':
+                    $this->setRestrictionDeny($param);
+                    break;
+                case 'gallery_loc':
+                    @trigger_error(
+                        'GoogleVideo parameter ' . $key . ' is deprecated since 2.3.0, use "gallery_location" parameter instead',
+                        E_USER_DEPRECATED
+                    );
+                    $this->setGalleryLocation($param);
+                    break;
+                case 'gallery_location':
+                    $this->setGalleryLocation($param);
+                    break;
+                case 'gallery_loc_title':
+                    @trigger_error(
+                        'GoogleVideo parameter ' . $key . ' is deprecated since 2.3.0, use "gallery_location_title" parameter instead',
+                        E_USER_DEPRECATED
+                    );
+                    $this->setGalleryLocationTitle($param);
+                    break;
+                case 'gallery_location_title':
+                    $this->setGalleryLocationTitle($param);
+                    break;
+                case 'requires_subscription':
+                    $this->setRequiresSubscription($param);
+                    break;
+                case 'uploader':
+                    $this->setUploader($param);
+                    break;
+                case 'uploader_info':
+                    $this->setUploaderInfo($param);
+                    break;
+                case 'platforms':
+                    $this->setPlatforms($param);
+                    break;
+                case 'platform_relationship':
+                    $this->setPlatformRelationship($param);
+                    break;
+                case 'live':
+                    $this->setLive($param);
+                    break;
+            }
         }
 
-        $this->setThumbnailLoc($thumnail_loc);
+        $this->setThumbnailLocation($thumbnailLocation);
         $this->setTitle($title);
         $this->setDescription($description);
 
-        if (!$this->content_loc && !$this->player_loc) {
-            throw new Exception\GoogleVideoException('The parameter content_loc or player_loc is required');
+        if (!$this->contentLocation && !$this->playerLocation) {
+            throw new Exception\GoogleVideoException('The parameter content_location or content_location is required');
         }
 
-        if (count($this->platforms) && !$this->platform_relationship) {
+        if (count($this->platforms) && !$this->platformRelationship) {
             throw new Exception\GoogleVideoException(
                 'The parameter platform_relationship is required when platform is set'
             );
         }
     }
 
+    public function __get(string $name)
+    {
+        $map = [
+            'thumbnail_loc' => 'thumbnailLocation',
+            'content_loc' => 'contentLocation',
+            'player_loc' => 'playerLocation',
+            'player_loc_allow_embed' => 'playerLocationAllowEmbed',
+            'player_loc_autoplay' => 'playerLocationAutoplay',
+            'expiration_date' => 'expirationDate',
+            'view_count' => 'viewCount',
+            'publication_date' => 'publicationDate',
+            'family_friendly' => 'familyFriendly',
+            'restriction_allow' => 'restrictionAllow',
+            'restriction_deny' => 'restrictionDeny',
+            'gallery_loc' => 'galleryLocation',
+            'gallery_loc_title' => 'galleryLocationTitle',
+            'requires_subscription' => 'requiresSubscription',
+            'uploader_info' => 'uploaderInformation',
+            'platform_relationship' => 'platformRelationship',
+        ];
+
+        if (array_key_exists($name, $map)) {
+            $newName = $map[$name];
+            @trigger_error(
+                sprintf('Property %s::$%s is deprecated since 2.3.0, use $%s instead.', __CLASS__, $name, $newName),
+                E_USER_DEPRECATED
+            );
+
+            return $this->{$newName};
+        }
+
+        trigger_error(sprintf('Undefined property: %s::$%s', __CLASS__, $name));
+
+        return null;
+    }
+
     /**
+     * @deprecated since 2.3.0, to be removed in 3.0.0
+     *
      * @param string $thumbnail_loc
      *
      * @return GoogleVideo
      */
     public function setThumbnailLoc($thumbnail_loc)
     {
-        $this->thumbnail_loc = $thumbnail_loc;
+        @trigger_error(
+            sprintf('Method %s is deprecated since 2.3.0, use %s::setThumbnailLocation instead.', __METHOD__, __CLASS__),
+            E_USER_DEPRECATED
+        );
+        $this->setThumbnailLocation($thumbnail_loc);
 
         return $this;
     }
 
     /**
+     * @param string $location
+     *
+     * @return GoogleVideo
+     */
+    public function setThumbnailLocation($location)
+    {
+        $this->thumbnailLocation = $location;
+
+        return $this;
+    }
+
+    /**
+     * @deprecated since 2.3.0, to be removed in 3.0.0
+     *
      * @return string
      */
     public function getThumbnailLoc()
     {
-        return $this->thumbnail_loc;
+        @trigger_error(
+            sprintf('Method %s is deprecated since 2.3.0, use %s::getThumbnailLocation instead.', __METHOD__, __CLASS__),
+            E_USER_DEPRECATED
+        );
+
+        return $this->getThumbnailLocation();
+    }
+
+    /**
+     * @return string
+     */
+    public function getThumbnailLocation()
+    {
+        return $this->thumbnailLocation;
     }
 
     /**
@@ -257,80 +430,200 @@ class GoogleVideo
     }
 
     /**
+     * @deprecated since 2.3.0, to be removed in 3.0.0
+     *
      * @param string $content_loc
      *
      * @return GoogleVideo
      */
     public function setContentLoc($content_loc)
     {
-        $this->content_loc = $content_loc;
+        @trigger_error(
+            sprintf('Method %s is deprecated since 2.3.0, use %s::setContentLocation instead.', __METHOD__, __CLASS__),
+            E_USER_DEPRECATED
+        );
+        $this->setContentLocation($content_loc);
 
         return $this;
     }
 
     /**
+     * @param string $location
+     *
+     * @return GoogleVideo
+     */
+    public function setContentLocation($location)
+    {
+        $this->contentLocation = $location;
+
+        return $this;
+    }
+
+    /**
+     * @deprecated since 2.3.0, to be removed in 3.0.0
+     *
      * @param string $player_loc
      *
      * @return GoogleVideo
      */
     public function setPlayerLoc($player_loc)
     {
-        $this->player_loc = $player_loc;
+        @trigger_error(
+            sprintf('Method %s is deprecated since 2.3.0, use %s::setPlayerLocation instead.', __METHOD__, __CLASS__),
+            E_USER_DEPRECATED
+        );
+        $this->setPlayerLocation($player_loc);
 
         return $this;
     }
 
     /**
+     * @param string $location
+     *
+     * @return GoogleVideo
+     */
+    public function setPlayerLocation($location)
+    {
+        $this->playerLocation = $location;
+
+        return $this;
+    }
+
+    /**
+     * @deprecated since 2.3.0, to be removed in 3.0.0
+     *
      * @return string|null
      */
     public function getPlayerLoc()
     {
-        return $this->player_loc;
+        @trigger_error(
+            sprintf('Method %s is deprecated since 2.3.0, use %s::getPlayerLocation instead.', __METHOD__, __CLASS__),
+            E_USER_DEPRECATED
+        );
+
+        return $this->getPlayerLocation();
     }
 
     /**
+     * @return string|null
+     */
+    public function getPlayerLocation()
+    {
+        return $this->playerLocation;
+    }
+
+    /**
+     * @deprecated since 2.3.0, to be removed in 3.0.0
+     *
      * @param string $player_loc_allow_embed
      *
      * @return GoogleVideo
      */
     public function setPlayerLocAllowEmbed($player_loc_allow_embed)
     {
-        if (!in_array($player_loc_allow_embed, [self::PLAYER_LOC_ALLOW_EMBED_YES, self::PLAYER_LOC_ALLOW_EMBED_NO])) {
-            throw new Exception\GoogleVideoException(
-                sprintf(
-                    'The parameter %s must be a valid player_loc_allow_embed.see http://support.google.com/webmasters/bin/answer.py?hl=en&answer=80472#4',
-                    $player_loc_allow_embed
-                )
-            );
-        }
-        $this->player_loc_allow_embed = $player_loc_allow_embed;
+        @trigger_error(
+            sprintf('Method %s is deprecated since 2.3.0, use %s::setPlayerLocationAllowEmbed instead.', __METHOD__, __CLASS__),
+            E_USER_DEPRECATED
+        );
+        $this->setPlayerLocationAllowEmbed($player_loc_allow_embed);
 
         return $this;
     }
 
     /**
+     * @param string $embed
+     *
+     * @return GoogleVideo
+     */
+    public function setPlayerLocationAllowEmbed($embed)
+    {
+        if (!in_array($embed, [self::PLAYER_LOC_ALLOW_EMBED_YES, self::PLAYER_LOC_ALLOW_EMBED_NO])) {
+            throw new Exception\GoogleVideoException(
+                sprintf(
+                    'The parameter %s must be a valid player_location_allow_embed. See http://support.google.com/webmasters/bin/answer.py?hl=en&answer=80472#4',
+                    $embed
+                )
+            );
+        }
+        $this->playerLocationAllowEmbed = $embed;
+
+        return $this;
+    }
+
+    /**
+     * @deprecated since 2.3.0, to be removed in 3.0.0
+     *
      * @return string
      */
     public function getPlayerLocAllowEmbed()
     {
-        return $this->player_loc_allow_embed;
+        @trigger_error(
+            sprintf('Method %s is deprecated since 2.3.0, use %s::getPlayerLocationAllowEmbed instead.', __METHOD__, __CLASS__),
+            E_USER_DEPRECATED
+        );
+
+        return $this->getPlayerLocationAllowEmbed();
     }
 
     /**
+     * @return string
+     */
+    public function getPlayerLocationAllowEmbed()
+    {
+        return $this->playerLocationAllowEmbed;
+    }
+
+    /**
+     * @deprecated since 2.3.0, to be removed in 3.0.0
+     *
      * @param string $player_loc_autoplay
      *
      * @return GoogleVideo
      */
     public function setPlayerLocAutoplay($player_loc_autoplay)
     {
-        $this->player_loc_autoplay = $player_loc_autoplay;
+        @trigger_error(
+            sprintf('Method %s is deprecated since 2.3.0, use %s::setPlayerLocationAutoplay instead.', __METHOD__, __CLASS__),
+            E_USER_DEPRECATED
+        );
+        $this->setPlayerLocationAutoplay($player_loc_autoplay);
 
         return $this;
     }
 
+    /**
+     * @param string $autoplay
+     *
+     * @return GoogleVideo
+     */
+    public function setPlayerLocationAutoplay($autoplay)
+    {
+        $this->playerLocationAutoplay = $autoplay;
+
+        return $this;
+    }
+
+    /**
+     * @deprecated since 2.3.0, to be removed in 3.0.0
+     *
+     * @return string
+     */
     public function getPlayerLocAutoplay()
     {
-        return $this->player_loc_autoplay;
+        @trigger_error(
+            sprintf('Method %s is deprecated since 2.3.0, use %s::getPlayerLocationAutoplay instead.', __METHOD__, __CLASS__),
+            E_USER_DEPRECATED
+        );
+
+        return $this->getPlayerLocationAutoplay();
+    }
+
+    /**
+     * @return string
+     */
+    public function getPlayerLocationAutoplay()
+    {
+        return $this->playerLocationAutoplay;
     }
 
     /**
@@ -344,7 +637,7 @@ class GoogleVideo
         if ($duration < 0 || $duration > 28800) {
             throw new Exception\GoogleVideoException(
                 sprintf(
-                    'The parameter %s must be a valid duration.see http://support.google.com/webmasters/bin/answer.py?hl=en&answer=80472#4',
+                    'The parameter %s must be a valid duration. See http://support.google.com/webmasters/bin/answer.py?hl=en&answer=80472#4',
                     $duration
                 )
             );
@@ -356,13 +649,13 @@ class GoogleVideo
     }
 
     /**
-     * @param DateTimeInterface $expiration_date
+     * @param DateTimeInterface $expirationDate
      *
      * @return GoogleVideo
      */
-    public function setExpirationDate(DateTimeInterface $expiration_date)
+    public function setExpirationDate(DateTimeInterface $expirationDate)
     {
-        $this->expiration_date = $expiration_date;
+        $this->expirationDate = $expirationDate;
 
         return $this;
     }
@@ -377,7 +670,7 @@ class GoogleVideo
         if ($rating < 0 || $rating > 5) {
             throw new Exception\GoogleVideoException(
                 sprintf(
-                    'The parameter %s must be a valid rating.see http://support.google.com/webmasters/bin/answer.py?hl=en&answer=80472#4',
+                    'The parameter %s must be a valid rating. See http://support.google.com/webmasters/bin/answer.py?hl=en&answer=80472#4',
                     $rating
                 )
             );
@@ -389,50 +682,50 @@ class GoogleVideo
     }
 
     /**
-     * @param int $view_count
+     * @param int $viewCount
      *
      * @return GoogleVideo
      */
-    public function setViewCount($view_count)
+    public function setViewCount($viewCount)
     {
-        $this->view_count = $view_count;
+        $this->viewCount = $viewCount;
 
         return $this;
     }
 
     /**
-     * @param DateTimeInterface $publication_date
+     * @param DateTimeInterface $publicationDate
      *
      * @return GoogleVideo
      */
-    public function setPublicationDate(DateTimeInterface $publication_date)
+    public function setPublicationDate(DateTimeInterface $publicationDate)
     {
-        $this->publication_date = $publication_date;
+        $this->publicationDate = $publicationDate;
 
         return $this;
     }
 
     /**
-     * @param null|string $family_friendly
+     * @param null|string $familyFriendly
      *
      * @return GoogleVideo
      */
-    public function setFamilyFriendly($family_friendly = null)
+    public function setFamilyFriendly($familyFriendly = null)
     {
-        if (null == $family_friendly) {
-            $family_friendly = self::FAMILY_FRIENDLY_YES;
+        if (null == $familyFriendly) {
+            $familyFriendly = self::FAMILY_FRIENDLY_YES;
         }
 
-        if (!in_array($family_friendly, [self::FAMILY_FRIENDLY_YES, self::FAMILY_FRIENDLY_NO])) {
+        if (!in_array($familyFriendly, [self::FAMILY_FRIENDLY_YES, self::FAMILY_FRIENDLY_NO])) {
             throw new Exception\GoogleVideoException(
                 sprintf(
-                    'The parameter %s must be a valid family_friendly. see http://support.google.com/webmasters/bin/answer.py?hl=en&answer=80472#4',
-                    $family_friendly
+                    'The parameter %s must be a valid family_friendly. See http://support.google.com/webmasters/bin/answer.py?hl=en&answer=80472#4',
+                    $familyFriendly
                 )
             );
         }
 
-        $this->family_friendly = $family_friendly;
+        $this->familyFriendly = $familyFriendly;
 
         return $this;
     }
@@ -447,7 +740,7 @@ class GoogleVideo
         if (strlen($category) > 256) {
             throw new Exception\GoogleVideoException(
                 sprintf(
-                    'The parameter %s must be a valid category. see http://support.google.com/webmasters/bin/answer.py?hl=en&answer=80472#4',
+                    'The parameter %s must be a valid category. See http://support.google.com/webmasters/bin/answer.py?hl=en&answer=80472#4',
                     $category
                 )
             );
@@ -465,7 +758,7 @@ class GoogleVideo
      */
     public function setRestrictionAllow(array $countries)
     {
-        $this->restriction_allow = $countries;
+        $this->restrictionAllow = $countries;
 
         return $this;
     }
@@ -475,7 +768,7 @@ class GoogleVideo
      */
     public function getRestrictionAllow()
     {
-        return $this->restriction_allow;
+        return $this->restrictionAllow;
     }
 
     /**
@@ -485,7 +778,7 @@ class GoogleVideo
      */
     public function setRestrictionDeny(array $countries)
     {
-        $this->restriction_deny = $countries;
+        $this->restrictionDeny = $countries;
 
         return $this;
     }
@@ -495,50 +788,86 @@ class GoogleVideo
      */
     public function getRestrictionDeny()
     {
-        return $this->restriction_deny;
+        return $this->restrictionDeny;
     }
 
     /**
+     * @deprecated since 2.3.0, to be removed in 3.0.0
+     *
      * @param string $gallery_loc
      *
      * @return GoogleVideo
      */
     public function setGalleryLoc($gallery_loc)
     {
-        $this->gallery_loc = $gallery_loc;
+        @trigger_error(
+            sprintf('Method %s is deprecated since 2.3.0, use %s::setGalleryLocation instead.', __METHOD__, __CLASS__),
+            E_USER_DEPRECATED
+        );
+        $this->setGalleryLocation($gallery_loc);
 
         return $this;
     }
 
     /**
+     * @param string $location
+     *
+     * @return GoogleVideo
+     */
+    public function setGalleryLocation($location)
+    {
+        $this->galleryLocation = $location;
+
+        return $this;
+    }
+
+    /**
+     * @deprecated since 2.3.0, to be removed in 3.0.0
+     *
      * @param string $gallery_loc_title
      *
      * @return GoogleVideo
      */
     public function setGalleryLocTitle($gallery_loc_title)
     {
-        $this->gallery_loc_title = $gallery_loc_title;
+        @trigger_error(
+            sprintf('Method %s is deprecated since 2.3.0, use %s::setGalleryLocationTitle instead.', __METHOD__, __CLASS__),
+            E_USER_DEPRECATED
+        );
+        $this->setGalleryLocationTitle($gallery_loc_title);
 
         return $this;
     }
 
     /**
-     * @param string $requires_subscription
+     * @param string $title
      *
      * @return GoogleVideo
      */
-    public function setRequiresSubscription($requires_subscription)
+    public function setGalleryLocationTitle($title)
     {
-        if (!in_array($requires_subscription, [self::REQUIRES_SUBSCRIPTION_YES, self::REQUIRES_SUBSCRIPTION_NO])) {
+        $this->galleryLocationTitle = $title;
+
+        return $this;
+    }
+
+    /**
+     * @param string $requiresSubscription
+     *
+     * @return GoogleVideo
+     */
+    public function setRequiresSubscription($requiresSubscription)
+    {
+        if (!in_array($requiresSubscription, [self::REQUIRES_SUBSCRIPTION_YES, self::REQUIRES_SUBSCRIPTION_NO])) {
             throw new Exception\GoogleVideoException(
                 sprintf(
-                    'The parameter %s must be a valid requires_subscription.see http://support.google.com/webmasters/bin/answer.py?hl=en&answer=80472#4',
-                    $requires_subscription
+                    'The parameter %s must be a valid requires_subscription. See http://support.google.com/webmasters/bin/answer.py?hl=en&answer=80472#4',
+                    $requiresSubscription
                 )
             );
         }
 
-        $this->requires_subscription = $requires_subscription;
+        $this->requiresSubscription = $requiresSubscription;
 
         return $this;
     }
@@ -556,13 +885,13 @@ class GoogleVideo
     }
 
     /**
-     * @param string $uploader_info
+     * @param string $uploaderInfo
      *
      * @return GoogleVideo
      */
-    public function setUploaderInfo($uploader_info)
+    public function setUploaderInfo($uploaderInfo)
     {
-        $this->uploader_info = $uploader_info;
+        $this->uploaderInfo = $uploaderInfo;
 
         return $this;
     }
@@ -588,13 +917,13 @@ class GoogleVideo
     }
 
     /**
-     * @param string $platform_relationship
+     * @param string $platformRelationship
      *
      * @return GoogleVideo
      */
-    public function setPlatformRelationship($platform_relationship)
+    public function setPlatformRelationship($platformRelationship)
     {
-        $this->platform_relationship = $platform_relationship;
+        $this->platformRelationship = $platformRelationship;
 
         return $this;
     }
@@ -604,7 +933,7 @@ class GoogleVideo
      */
     public function getPlatformRelationship()
     {
-        return $this->platform_relationship;
+        return $this->platformRelationship;
     }
 
     /**
@@ -636,11 +965,26 @@ class GoogleVideo
     }
 
     /**
+     * @deprecated since 2.3.0, to be removed in 3.0.0
+     *
      * @return null|string
      */
     public function getContentLoc()
     {
-        return $this->content_loc;
+        @trigger_error(
+            sprintf('Method %s is deprecated since 2.3.0, use %s::getContentLocation instead.', __METHOD__, __CLASS__),
+            E_USER_DEPRECATED
+        );
+
+        return $this->getContentLocation();
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getContentLocation()
+    {
+        return $this->contentLocation;
     }
 
     /**
@@ -656,7 +1000,7 @@ class GoogleVideo
      */
     public function getExpirationDate()
     {
-        return $this->expiration_date;
+        return $this->expirationDate;
     }
 
     /**
@@ -672,7 +1016,7 @@ class GoogleVideo
      */
     public function getViewCount()
     {
-        return $this->view_count;
+        return $this->viewCount;
     }
 
     /**
@@ -680,7 +1024,7 @@ class GoogleVideo
      */
     public function getPublicationDate()
     {
-        return $this->publication_date;
+        return $this->publicationDate;
     }
 
     /**
@@ -688,7 +1032,7 @@ class GoogleVideo
      */
     public function getFamilyFriendly()
     {
-        return $this->family_friendly;
+        return $this->familyFriendly;
     }
 
     /**
@@ -700,19 +1044,49 @@ class GoogleVideo
     }
 
     /**
+     * @deprecated since 2.3.0, to be removed in 3.0.0
+     *
      * @return null|string
      */
     public function getGalleryLoc()
     {
-        return $this->gallery_loc;
+        @trigger_error(
+            sprintf('Method %s is deprecated since 2.3.0, use %s::getGalleryLocation instead.', __METHOD__, __CLASS__),
+            E_USER_DEPRECATED
+        );
+
+        return $this->getGalleryLocation();
     }
 
     /**
      * @return null|string
      */
+    public function getGalleryLocation()
+    {
+        return $this->galleryLocation;
+    }
+
+    /**
+     * @deprecated since 2.3.0, to be removed in 3.0.0
+     *
+     * @return null|string
+     */
     public function getGalleryLocTitle()
     {
-        return $this->gallery_loc_title;
+        @trigger_error(
+            sprintf('Method %s is deprecated since 2.3.0, use %s::getGalleryLocationTitle instead.', __METHOD__, __CLASS__),
+            E_USER_DEPRECATED
+        );
+
+        return $this->getGalleryLocationTitle();
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getGalleryLocationTitle()
+    {
+        return $this->galleryLocationTitle;
     }
 
     /**
@@ -720,7 +1094,7 @@ class GoogleVideo
      */
     public function getRequiresSubscription()
     {
-        return $this->requires_subscription;
+        return $this->requiresSubscription;
     }
 
     /**
@@ -736,7 +1110,7 @@ class GoogleVideo
      */
     public function getUploaderInfo()
     {
-        return $this->uploader_info;
+        return $this->uploaderInfo;
     }
 
     /**
@@ -807,7 +1181,9 @@ class GoogleVideo
     }
 
     /**
-     * @inheritdoc
+     * Return the xml representation for the video
+     *
+     * @return string
      */
     public function toXml()
     {
@@ -815,105 +1191,127 @@ class GoogleVideo
 
         //----------------------
         // required fields
-        $videoXml .= '<video:thumbnail_loc>' . Utils::encode($this->getThumbnailLoc()) . '</video:thumbnail_loc>';
+        $videoXml .= '<video:thumbnail_loc>' . Utils::encode($this->getThumbnailLocation()) . '</video:thumbnail_loc>';
+        $videoXml .= '<video:title>' . Utils::cdata($this->getTitle()) . '</video:title>';
+        $videoXml .= '<video:description>' . Utils::cdata($this->getDescription()) . '</video:description>';
 
-        foreach (['title', 'description'] as $paramName) {
-            $videoXml .= '<video:' . $paramName . '>' . Utils::render(
-                    $this->{Utils::getGetMethod($this, $paramName)}()
-                ) . '</video:' . $paramName . '>';
-        }
         //----------------------
         //----------------------
-        // simple optionnal fields
-        if ($this->getCategory()) {
-            $videoXml .= '<video:category>' . Utils::render($this->getCategory()) . '</video:category>';
+        // simple optional fields
+        if ($category = $this->getCategory()) {
+            $videoXml .= '<video:category>' . Utils::cdata($category) . '</video:category>';
         }
-        if ($this->getContentLoc()) {
-            $videoXml .= '<video:content_loc>' . Utils::encode($this->getContentLoc()) . '</video:content_loc>';
+        if ($location = $this->getContentLocation()) {
+            $videoXml .= '<video:content_loc>' . Utils::encode($location) . '</video:content_loc>';
         }
-        foreach ([
-                     'duration',
-                     'rating',
-                     'view_count',
-                     'family_friendly',
-                     'requires_subscription',
-                     'live',
-                 ] as $paramName) {
-            $getMethod = Utils::getGetMethod($this, $paramName);
-            if ($this->$getMethod()) {
-                $videoXml .= '<video:' . $paramName . '>' . $this->$getMethod() . '</video:' . $paramName . '>';
+        if ($duration = $this->getDuration()) {
+            $videoXml .= '<video:duration>' . $duration . '</video:duration>';
+        }
+        if ($rating = $this->getRating()) {
+            $videoXml .= '<video:rating>' . $rating . '</video:rating>';
+        }
+        if ($viewCount = $this->getViewCount()) {
+            $videoXml .= '<video:view_count>' . $viewCount . '</video:view_count>';
+        }
+        if ($familyFriendly = $this->getFamilyFriendly()) {
+            $videoXml .= '<video:family_friendly>' . $familyFriendly . '</video:family_friendly>';
+        }
+        if ($requiresSubscription = $this->getRequiresSubscription()) {
+            $videoXml .= '<video:requires_subscription>' . $requiresSubscription . '</video:requires_subscription>';
+        }
+        if ($live = $this->getLive()) {
+            $videoXml .= '<video:live>' . $live . '</video:live>';
+        }
+
+        //----------------------
+        //----------------------
+        // date based optional fields
+        if ($date = $this->getExpirationDate()) {
+            $videoXml .= '<video:expiration_date>' . $date->format('c') . '</video:expiration_date>';
+        }
+        if ($date = $this->getPublicationDate()) {
+            $videoXml .= '<video:publication_date>' . $date->format('c') . '</video:publication_date>';
+        }
+
+        //----------------------
+        //----------------------
+        // more complex optional fields
+        if ($playerLocation = $this->getPlayerLocation()) {
+            $attributes = [];
+            if ($uploaderInfo = $this->getPlayerLocationAllowEmbed()) {
+                $attributes['allow_embed'] = Utils::encode($uploaderInfo);
             }
-        }
-        //----------------------
-        //----------------------
-        // date based optionnal fields
-        foreach (['expiration_date', 'publication_date'] as $paramName) {
-            $getMethod = Utils::getGetMethod($this, $paramName);
-            if ($this->$getMethod()) {
-                $videoXml .= '<video:' . $paramName . '>' . $this->$getMethod()->format(
-                        'c'
-                    ) . '</video:' . $paramName . '>';
+            if ($autoplay = $this->getPlayerLocationAutoplay()) {
+                $attributes['autoplay'] = Utils::encode($autoplay);
             }
-        }
-        //----------------------
-        //----------------------
-        // moar complexe optionnal fields
-        if ($this->getPlayerLoc()) {
-            $allow_embed = ($this->getPlayerLocAllowEmbed()) ? ' allow_embed="' . $this->getPlayerLocAllowEmbed(
-                ) . '"' : '';
-            $autoplay = ($this->getPlayerLocAutoplay()) ? ' autoplay="' . $this->getPlayerLocAutoplay() . '"' : '';
-            $videoXml .= '<video:player_loc' . $allow_embed . $autoplay . '>' . Utils::encode(
-                    $this->getPlayerLoc()
-                ) . '</video:player_loc>';
+
+            $videoXml .= '<video:player_loc' . $this->attributes($attributes) . '>'
+                . Utils::encode($playerLocation)
+                . '</video:player_loc>';
         }
 
-        if ($this->getRestrictionAllow()) {
-            $videoXml .= '<video:restriction relationship="allow">' . implode(
-                    ' ',
-                    $this->getRestrictionAllow()
-                ) . '</video:restriction>';
+        if ($allow = $this->getRestrictionAllow()) {
+            $videoXml .= '<video:restriction relationship="allow">' . implode(' ', $allow) . '</video:restriction>';
         }
 
-        if ($this->getRestrictionDeny()) {
-            $videoXml .= '<video:restriction relationship="deny">' . implode(
-                    ' ',
-                    $this->getRestrictionDeny()
-                ) . '</video:restriction>';
+        if ($deny = $this->getRestrictionDeny()) {
+            $videoXml .= '<video:restriction relationship="deny">' . implode(' ', $deny) . '</video:restriction>';
         }
 
-        if ($this->getGalleryLoc()) {
-            $title = ($this->getGalleryLocTitle()) ? ' title="' . Utils::encode($this->getGalleryLocTitle()) . '"' : '';
-            $videoXml .= '<video:gallery_loc' . $title . '>' . Utils::encode(
-                    $this->getGalleryLoc()
-                ) . '</video:gallery_loc>';
+        if ($galleryLocation = $this->getGalleryLocation()) {
+            $attributes = [];
+            if ($galleryLocationTitle = $this->getGalleryLocationTitle()) {
+                $attributes['title'] = Utils::encode($galleryLocationTitle);
+            }
+
+            $videoXml .= '<video:gallery_loc' . $this->attributes($attributes) . '>'
+                . Utils::encode($galleryLocation)
+                . '</video:gallery_loc>';
         }
 
         foreach ($this->getTags() as $tag) {
-            $videoXml .= '<video:tag>' . Utils::render($tag) . '</video:tag>';
+            $videoXml .= '<video:tag>' . Utils::cdata($tag) . '</video:tag>';
         }
 
         foreach ($this->getPrices() as $price) {
-            $type = ($price['type']) ? ' type="' . $price['type'] . '"' : '';
-            $resolution = ($price['resolution']) ? ' resolution="' . $price['resolution'] . '"' : '';
-            $videoXml .= '<video:price currency="' . $price['currency'] . '"' . $type . $resolution . '>' . $price['amount'] . '</video:price>';
+            $attributes = array_intersect_key($price, array_flip(['currency', 'type', 'resolution']));
+            $attributes = array_filter($attributes);
+
+            $videoXml .= '<video:price' . $this->attributes($attributes) . '>' . $price['amount'] . '</video:price>';
         }
 
-        if ($this->getUploader()) {
-            $info = ($this->getUploaderInfo()) ? ' info="' . $this->getUploaderInfo() . '"' : '';
-            $videoXml .= '<video:uploader' . $info . '>' . $this->getUploader() . '</video:uploader>';
+        if ($uploader = $this->getUploader()) {
+            $attributes = [];
+            if ($uploaderInfo = $this->getUploaderInfo()) {
+                $attributes['info'] = $uploaderInfo;
+            }
+
+            $videoXml .= '<video:uploader' . $this->attributes($attributes) . '>' . $uploader . '</video:uploader>';
         }
 
-        if (count($this->getPlatforms())) {
-            $relationship = $this->getPlatformRelationship();
-            $videoXml .= '<video:platform relationship="' . $relationship . '">' . implode(
-                    ' ',
-                    $this->getPlatforms()
-                ) . '</video:platform>';
+        if (count($platforms = $this->getPlatforms())) {
+            $videoXml .= '<video:platform relationship="' . $this->getPlatformRelationship() . '">'
+                . implode(' ', $platforms)
+                . '</video:platform>';
         }
         //----------------------
 
         $videoXml .= '</video:video>';
 
         return $videoXml;
+    }
+
+    private function attributes(array $map): string
+    {
+        $attributes = '';
+        if (\count($map) === 0) {
+            return $attributes;
+        }
+
+        foreach ($map as $name => $value) {
+            $attributes .= ' ' . $name . '="' . $value . '"';
+        }
+
+        return ' ' . trim($attributes);
     }
 }

--- a/Sitemap/Url/GoogleVideo.php
+++ b/Sitemap/Url/GoogleVideo.php
@@ -316,7 +316,7 @@ class GoogleVideo
         }
     }
 
-    public function __get(string $name)
+    public function __get($name)
     {
         $map = [
             'thumbnail_loc' => 'thumbnailLocation',
@@ -352,7 +352,7 @@ class GoogleVideo
         return null;
     }
 
-    public function __set(string $name, $value)
+    public function __set($name, $value)
     {
         $map = [
             'thumbnail_loc' => 'thumbnailLocation',

--- a/Sitemap/Url/GoogleVideoUrlDecorator.php
+++ b/Sitemap/Url/GoogleVideoUrlDecorator.php
@@ -11,6 +11,7 @@
 
 namespace Presta\SitemapBundle\Sitemap\Url;
 
+use DateTimeInterface;
 use Presta\SitemapBundle\Exception;
 
 /**
@@ -257,7 +258,7 @@ class GoogleVideoUrlDecorator extends UrlDecorator
     {
         $this->bc(__FUNCTION__);
 
-        $this->video->setThumbnailLoc($thumbnail_loc);
+        $this->video->setThumbnailLocation($thumbnail_loc);
 
         return $this;
     }
@@ -271,7 +272,7 @@ class GoogleVideoUrlDecorator extends UrlDecorator
     {
         $this->bc(__FUNCTION__);
 
-        return $this->video->getThumbnailLoc();
+        return $this->video->getThumbnailLocation();
     }
 
     /**
@@ -317,7 +318,7 @@ class GoogleVideoUrlDecorator extends UrlDecorator
     {
         $this->bc(__FUNCTION__);
 
-        $this->video->setContentLoc($content_loc);
+        $this->video->setContentLocation($content_loc);
 
         return $this;
     }
@@ -333,7 +334,7 @@ class GoogleVideoUrlDecorator extends UrlDecorator
     {
         $this->bc(__FUNCTION__);
 
-        $this->video->setPlayerLoc($player_loc);
+        $this->video->setPlayerLocation($player_loc);
 
         return $this;
     }
@@ -347,7 +348,7 @@ class GoogleVideoUrlDecorator extends UrlDecorator
     {
         $this->bc(__FUNCTION__);
 
-        return $this->video->getPlayerLoc();
+        return $this->video->getPlayerLocation();
     }
 
     /**
@@ -361,7 +362,7 @@ class GoogleVideoUrlDecorator extends UrlDecorator
     {
         $this->bc(__FUNCTION__);
 
-        $this->video->setPlayerLocAllowEmbed($player_loc_allow_embed);
+        $this->video->setPlayerLocationAllowEmbed($player_loc_allow_embed);
 
         return $this;
     }
@@ -375,7 +376,7 @@ class GoogleVideoUrlDecorator extends UrlDecorator
     {
         $this->bc(__FUNCTION__);
 
-        return $this->video->getPlayerLocAllowEmbed();
+        return $this->video->getPlayerLocationAllowEmbed();
     }
 
     /**
@@ -389,7 +390,7 @@ class GoogleVideoUrlDecorator extends UrlDecorator
     {
         $this->bc(__FUNCTION__);
 
-        $this->video->setPlayerLocAutoplay($player_loc_autoplay);
+        $this->video->setPlayerLocationAutoplay($player_loc_autoplay);
 
         return $this;
     }
@@ -401,7 +402,7 @@ class GoogleVideoUrlDecorator extends UrlDecorator
     {
         $this->bc(__FUNCTION__);
 
-        return $this->video->getPlayerLocAutoplay();
+        return $this->video->getPlayerLocationAutoplay();
     }
 
     /**
@@ -584,7 +585,7 @@ class GoogleVideoUrlDecorator extends UrlDecorator
     {
         $this->bc(__FUNCTION__);
 
-        $this->video->setGalleryLoc($gallery_loc);
+        $this->video->setGalleryLocation($gallery_loc);
 
         return $this;
     }
@@ -600,7 +601,7 @@ class GoogleVideoUrlDecorator extends UrlDecorator
     {
         $this->bc(__FUNCTION__);
 
-        $this->video->setGalleryLocTitle($gallery_loc_title);
+        $this->video->setGalleryLocationTitle($gallery_loc_title);
 
         return $this;
     }
@@ -758,7 +759,7 @@ class GoogleVideoUrlDecorator extends UrlDecorator
     {
         $this->bc(__FUNCTION__);
 
-        return $this->video->getContentLoc();
+        return $this->video->getContentLocation();
     }
 
     /**
@@ -854,7 +855,7 @@ class GoogleVideoUrlDecorator extends UrlDecorator
     {
         $this->bc(__FUNCTION__);
 
-        return $this->video->getGalleryLoc();
+        return $this->video->getGalleryLocation();
     }
 
     /**
@@ -866,7 +867,7 @@ class GoogleVideoUrlDecorator extends UrlDecorator
     {
         $this->bc(__FUNCTION__);
 
-        return $this->video->getGalleryLocTitle();
+        return $this->video->getGalleryLocationTitle();
     }
 
     /**

--- a/Sitemap/Utils.php
+++ b/Sitemap/Utils.php
@@ -13,10 +13,6 @@ namespace Presta\SitemapBundle\Sitemap;
 
 use Presta\SitemapBundle\Exception\Exception;
 
-if (!defined('ENT_SUBSTITUTE')) {
-    define('ENT_SUBSTITUTE', 8);
-}
-
 /**
  * Description of Utils
  *
@@ -25,6 +21,8 @@ if (!defined('ENT_SUBSTITUTE')) {
 class Utils
 {
     /**
+     * @deprecated since 2.3.0, to be removed in 3.0.0
+     *
      * Verify method affiliated to given param
      *
      * @param object $object
@@ -34,6 +32,11 @@ class Utils
      */
     public static function getSetMethod($object, $name)
     {
+        @trigger_error(
+            sprintf('Method %s is deprecated since 2.3.0.', __METHOD__),
+            E_USER_DEPRECATED
+        );
+
         $methodName = 'set' . self::camelize($name);
 
         if (!method_exists($object, $methodName)) {
@@ -44,6 +47,8 @@ class Utils
     }
 
     /**
+     * @deprecated since 2.3.0, to be removed in 3.0.0
+     *
      * Verify method affiliated to given param
      *
      * @param object $object
@@ -54,6 +59,11 @@ class Utils
      */
     public static function getGetMethod($object, $name)
     {
+        @trigger_error(
+            sprintf('Method %s is deprecated since 2.3.0.', __METHOD__),
+            E_USER_DEPRECATED
+        );
+
         $methodName = 'get' . self::camelize($name);
 
         if (!method_exists($object, $methodName)) {
@@ -64,7 +74,9 @@ class Utils
     }
 
     /**
-     * Render a string as CDATA section
+     * @deprecated since 2.3.0, to be removed in 3.0.0
+     *
+     * Legacy alias of Utils::cdata
      *
      * @param string $string
      *
@@ -72,11 +84,28 @@ class Utils
      */
     public static function render($string)
     {
+        @trigger_error(
+            sprintf('Method %s is deprecated since 2.3.0, use %s::cdata instead.', __METHOD__, __CLASS__),
+            E_USER_DEPRECATED
+        );
+
+        return self::cdata($string);
+    }
+
+    /**
+     * Wrap string with CDATA markup
+     *
+     * @param string $string
+     *
+     * @return string
+     */
+    public static function cdata($string)
+    {
         return '<![CDATA[' . $string . ']]>';
     }
 
     /**
-     * Encode special chars
+     * Encode string with html special chars
      *
      * @param string $string
      *
@@ -96,6 +125,11 @@ class Utils
      */
     public static function camelize($string)
     {
+        @trigger_error(
+            sprintf('Method %s is deprecated since 2.3.0.', __METHOD__),
+            E_USER_DEPRECATED
+        );
+
         return str_replace(' ', '', ucwords(str_replace('_', ' ', $string)));
     }
 }

--- a/Tests/Integration/src/Listener/SitemapListener.php
+++ b/Tests/Integration/src/Listener/SitemapListener.php
@@ -91,7 +91,7 @@ final class SitemapListener implements EventSubscriberInterface
                         sprintf('https://img.youtube.com/vi/%s/0.jpg', $parameters['v']),
                         $post['title'],
                         $post['title'],
-                        ['content_loc' => $post['video']]
+                        ['content_location' => $post['video']]
                     )
                 );
             }

--- a/Tests/Unit/Sitemap/Url/GoogleImageTest.php
+++ b/Tests/Unit/Sitemap/Url/GoogleImageTest.php
@@ -22,11 +22,17 @@ class GoogleImageTest extends TestCase
     /**
      * @dataProvider toXmlProvider
      */
-    public function testToXml($expectedXml, $loc, $caption = null, $geoLocalisation = null, $title = null, $license = null): void
-    {
+    public function testToXml(
+        string $expectedXml,
+        string $location,
+        string $caption,
+        string $geoLocalisation = null,
+        string $title = null,
+        string $license = null
+    ): void {
         $failed = false;
         try {
-            $image = new Sitemap\Url\GoogleImage($loc, $caption, $geoLocalisation, $title, $license);
+            $image = new Sitemap\Url\GoogleImage($location, $caption, $geoLocalisation, $title, $license);
         } catch (\RuntimeException $e) {
             $failed = true;
         }
@@ -35,22 +41,50 @@ class GoogleImageTest extends TestCase
         self::assertEquals($expectedXml, $image->toXML());
     }
 
-    public function toXmlProvider(): array
+    public function toXmlProvider(): \Generator
     {
-        return [
-            [
-                '<image:image><image:loc>http://acme.com/logo.jpg</image:loc><image:caption><![CDATA[this is about logo]]></image:caption><image:geo_location><![CDATA[Lyon, France]]></image:geo_location><image:title><![CDATA[The Acme logo]]></image:title><image:license><![CDATA[WTFPL]]></image:license></image:image>',
-                'http://acme.com/logo.jpg',
-                'this is about logo',
-                'Lyon, France',
-                'The Acme logo',
-                'WTFPL'
-            ],
-            [
-                '<image:image><image:loc>http://acme.com/logo.jpg?a=&amp;b=c</image:loc><image:caption><![CDATA[this is about <strong>logo</strong>]]></image:caption></image:image>',
-                'http://acme.com/logo.jpg?a=&b=c',
-                'this is about <strong>logo</strong>'
-            ],
+        yield [
+            '<image:image><image:loc>http://acme.com/logo.jpg</image:loc><image:caption><![CDATA[this is about logo]]></image:caption><image:geo_location><![CDATA[Lyon, France]]></image:geo_location><image:title><![CDATA[The Acme logo]]></image:title><image:license><![CDATA[WTFPL]]></image:license></image:image>',
+            'http://acme.com/logo.jpg',
+            'this is about logo',
+            'Lyon, France',
+            'The Acme logo',
+            'WTFPL'
         ];
+        yield [
+            '<image:image><image:loc>http://acme.com/logo.jpg?a=&amp;b=c</image:loc><image:caption><![CDATA[this is about <strong>logo</strong>]]></image:caption></image:image>',
+            'http://acme.com/logo.jpg?a=&b=c',
+            'this is about <strong>logo</strong>'
+        ];
+    }
+
+    /**
+     * Assert that developers that have extends GoogleVideo
+     * and use old named attributes still has functional code with deprecations.
+     *
+     * @group legacy
+     */
+    public function testLegacyAccessors(): void
+    {
+        $image = new class('loc') extends Sitemap\Url\GoogleImage {
+            public function getLocLegacy()
+            {
+                return $this->loc;
+            }
+
+            public function getGeoLocationLegacy()
+            {
+                return $this->geo_location;
+            }
+        };
+
+        $image->setLoc('http://acme.com/logo.jpg');
+        self::assertSame('http://acme.com/logo.jpg', $image->getLoc());
+        self::assertSame('http://acme.com/logo.jpg', $image->getLocLegacy());
+        self::assertSame('http://acme.com/logo.jpg', $image->getLocation());
+
+        $image->setGeoLocation('Lyon, France');
+        self::assertSame('Lyon, France', $image->getGeoLocation());
+        self::assertSame('Lyon, France', $image->getGeoLocationLegacy());
     }
 }

--- a/Tests/Unit/Sitemap/Url/GoogleImageTest.php
+++ b/Tests/Unit/Sitemap/Url/GoogleImageTest.php
@@ -72,9 +72,19 @@ class GoogleImageTest extends TestCase
                 return $this->loc;
             }
 
+            public function setLocLegacy($value)
+            {
+                $this->loc = $value;
+            }
+
             public function getGeoLocationLegacy()
             {
                 return $this->geo_location;
+            }
+
+            public function setGeoLocationLegacy($value)
+            {
+                $this->geo_location = $value;
             }
         };
 
@@ -82,9 +92,16 @@ class GoogleImageTest extends TestCase
         self::assertSame('http://acme.com/logo.jpg', $image->getLoc());
         self::assertSame('http://acme.com/logo.jpg', $image->getLocLegacy());
         self::assertSame('http://acme.com/logo.jpg', $image->getLocation());
+        $image->setLocLegacy('http://legacy.acme.com/logo.jpg');
+        self::assertSame('http://legacy.acme.com/logo.jpg', $image->getLoc());
+        self::assertSame('http://legacy.acme.com/logo.jpg', $image->getLocLegacy());
+        self::assertSame('http://legacy.acme.com/logo.jpg', $image->getLocation());
 
         $image->setGeoLocation('Lyon, France');
         self::assertSame('Lyon, France', $image->getGeoLocation());
         self::assertSame('Lyon, France', $image->getGeoLocationLegacy());
+        $image->setGeoLocationLegacy('Lugdunum, Gaule');
+        self::assertSame('Lugdunum, Gaule', $image->getGeoLocation());
+        self::assertSame('Lugdunum, Gaule', $image->getGeoLocationLegacy());
     }
 }

--- a/Tests/Unit/Sitemap/Url/GoogleImageUrlDecoratorTest.php
+++ b/Tests/Unit/Sitemap/Url/GoogleImageUrlDecoratorTest.php
@@ -12,6 +12,7 @@
 namespace Presta\SitemapBundle\Tests\Unit\Sitemap\Url;
 
 use PHPUnit\Framework\TestCase;
+use Presta\SitemapBundle\Exception\GoogleImageException;
 use Presta\SitemapBundle\Sitemap;
 
 /**
@@ -35,8 +36,23 @@ class GoogleImageUrlDecoratorTest extends TestCase
 
     public function testIsFull(): void
     {
+        $this->expectException(GoogleImageException::class);
+        $this->expectExceptionMessage('The image limit has been exceeded');
+
         $url = new Sitemap\Url\GoogleImageUrlDecorator(new Sitemap\Url\UrlConcrete('http://acme.com'));
+
         self::assertFalse($url->isFull());
+
+        // fill url with images while not full
+        do {
+            $url->addImage(new Sitemap\Url\GoogleImage('http://acme.com/logo.jpg'));
+        } while (!$url->isFull());
+
+        // url must be full here
+        self::assertTrue($url->isFull());
+
+        // now url is full, adding an image will throw an exception
+        $url->addImage(new Sitemap\Url\GoogleImage('http://acme.com/logo.jpg'));
     }
 
     public function testToXml(): void

--- a/Tests/Unit/Sitemap/Url/GoogleNewsUrlDecoratorTest.php
+++ b/Tests/Unit/Sitemap/Url/GoogleNewsUrlDecoratorTest.php
@@ -11,6 +11,7 @@
 
 namespace Presta\SitemapBundle\Tests\Unit\Sitemap\Url;
 
+use DateTime;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Presta\SitemapBundle\Exception\GoogleNewsUrlException;
@@ -166,15 +167,11 @@ class GoogleNewsUrlDecoratorTest extends TestCase
 
         $failed = false;
         try {
-            $url->setStockTickers(
-                [
-                    'NYSE:OWW',
-                    'NASDAQ:GTAT',
-                    'NYSE:AOL',
-                    'NASDAQ:ENDP',
-                    'CVE:GTA'
-                ]
-            );
+            $url->addStockTicker('NYSE:OWW');
+            $url->addStockTicker('NASDAQ:GTAT');
+            $url->addStockTicker('NYSE:AOL');
+            $url->addStockTicker('NASDAQ:ENDP');
+            $url->addStockTicker('CVE:GTA');
         } catch (GoogleNewsUrlException $e) {
             $failed = true;
         }
@@ -199,6 +196,78 @@ class GoogleNewsUrlDecoratorTest extends TestCase
         $stockNodes = $dom->getElementsByTagNameNS('http://www.google.com/schemas/sitemap-news/0.9', 'stock_tickers');
         self::assertEquals(1, $stockNodes->length, 'Could not find news:stock_tickers tag');
         self::assertEquals('NYSE:OWW, NASDAQ:GTAT', $stockNodes->item(0)->textContent, 'Stock tickers tag did not contain the right value');
+    }
+
+    public function testPublicationLanguageInvalidValue(): void
+    {
+        $this->expectException(GoogleNewsUrlException::class);
+        $this->expectExceptionMessage(
+            'Use a 2 oder 3 character long ISO 639 language code. Except for chinese use zh-cn or zh-tw.' .
+            'See https://support.google.com/webmasters/answer/74288?hl=en&ref_topic=10078'
+        );
+
+        $this->createExampleUrl()->setPublicationLanguage('6 char');
+    }
+
+    public function testPublicationDateFormatInvalidValue(): void
+    {
+        $this->expectException(GoogleNewsUrlException::class);
+        $this->expectExceptionMessage(
+            'The parameter ' . DATE_COOKIE . ' must be a valid date format.' .
+            ' See https://support.google.com/webmasters/answer/74288?hl=en'
+        );
+
+        $this->createExampleUrl()->setPublicationDateFormat(DATE_COOKIE);
+    }
+
+    /**
+     * @dataProvider toXml
+     */
+    public function testToXml(
+        string $expectedXml,
+        string $name,
+        string $language,
+        DateTime $date,
+        string $title,
+        string $access = null,
+        array $genres = [],
+        string $geoLocations = null,
+        array $keywords = [],
+        array $stockTickers = []
+    ): void {
+        $url = new GoogleNewsUrlDecorator(new UrlConcrete('http://acme.com/'), $name, $language, $date, $title);
+        $url->setAccess($access);
+        $url->setGenres($genres);
+        if ($geoLocations !== null) {
+            $url->setGeoLocations($geoLocations);
+        }
+        $url->setKeywords($keywords);
+        $url->setStockTickers($stockTickers);
+
+        self::assertSame($expectedXml, $url->toXml());
+    }
+
+    public function toXml(): \Generator
+    {
+        yield [
+            '<url><loc>http://acme.com/</loc><news:news><news:publication><news:name><![CDATA[Symfony Sitemap]]></news:name><news:language>fr</news:language></news:publication><news:publication_date>2020-01-01T10:00:00+01:00</news:publication_date><news:title><![CDATA[Setup sitemap with Symfony]]></news:title></news:news></url>',
+            'Symfony Sitemap',
+            'fr',
+            new DateTime('2020-01-01 10:00:00'),
+            'Setup sitemap with Symfony',
+        ];
+        yield [
+            '<url><loc>http://acme.com/</loc><news:news><news:publication><news:name><![CDATA[Symfony Sitemap]]></news:name><news:language>fr</news:language></news:publication><news:access>Registration</news:access><news:genres>Blog, Tech</news:genres><news:publication_date>2020-01-01T10:00:00+01:00</news:publication_date><news:title><![CDATA[Setup sitemap with Symfony]]></news:title><news:geo_locations>Lyon, France</news:geo_locations><news:keywords>symfony, sitemap</news:keywords><news:stock_tickers>NYSE:OWW, NASDAQ:GTAT</news:stock_tickers></news:news></url>',
+            'Symfony Sitemap',
+            'fr',
+            new DateTime('2020-01-01 10:00:00'),
+            'Setup sitemap with Symfony',
+            GoogleNewsUrlDecorator::ACCESS_REGISTRATION,
+            ['Blog', 'Tech'],
+            'Lyon, France',
+            ['symfony', 'sitemap'],
+            ['NYSE:OWW', 'NASDAQ:GTAT'],
+        ];
     }
 
     /**

--- a/Tests/Unit/Sitemap/Url/GoogleNewsUrlDecoratorTest.php
+++ b/Tests/Unit/Sitemap/Url/GoogleNewsUrlDecoratorTest.php
@@ -250,17 +250,17 @@ class GoogleNewsUrlDecoratorTest extends TestCase
     public function toXml(): \Generator
     {
         yield [
-            '<url><loc>http://acme.com/</loc><news:news><news:publication><news:name><![CDATA[Symfony Sitemap]]></news:name><news:language>fr</news:language></news:publication><news:publication_date>2020-01-01T10:00:00+01:00</news:publication_date><news:title><![CDATA[Setup sitemap with Symfony]]></news:title></news:news></url>',
+            '<url><loc>http://acme.com/</loc><news:news><news:publication><news:name><![CDATA[Symfony Sitemap]]></news:name><news:language>fr</news:language></news:publication><news:publication_date>2020-01-01T10:00:00+00:00</news:publication_date><news:title><![CDATA[Setup sitemap with Symfony]]></news:title></news:news></url>',
             'Symfony Sitemap',
             'fr',
-            new DateTime('2020-01-01 10:00:00'),
+            new DateTime('2020-01-01T10:00:00+00:00'),
             'Setup sitemap with Symfony',
         ];
         yield [
-            '<url><loc>http://acme.com/</loc><news:news><news:publication><news:name><![CDATA[Symfony Sitemap]]></news:name><news:language>fr</news:language></news:publication><news:access>Registration</news:access><news:genres>Blog, Tech</news:genres><news:publication_date>2020-01-01T10:00:00+01:00</news:publication_date><news:title><![CDATA[Setup sitemap with Symfony]]></news:title><news:geo_locations>Lyon, France</news:geo_locations><news:keywords>symfony, sitemap</news:keywords><news:stock_tickers>NYSE:OWW, NASDAQ:GTAT</news:stock_tickers></news:news></url>',
+            '<url><loc>http://acme.com/</loc><news:news><news:publication><news:name><![CDATA[Symfony Sitemap]]></news:name><news:language>fr</news:language></news:publication><news:access>Registration</news:access><news:genres>Blog, Tech</news:genres><news:publication_date>2020-01-01T10:00:00+00:00</news:publication_date><news:title><![CDATA[Setup sitemap with Symfony]]></news:title><news:geo_locations>Lyon, France</news:geo_locations><news:keywords>symfony, sitemap</news:keywords><news:stock_tickers>NYSE:OWW, NASDAQ:GTAT</news:stock_tickers></news:news></url>',
             'Symfony Sitemap',
             'fr',
-            new DateTime('2020-01-01 10:00:00'),
+            new DateTime('2020-01-01T10:00:00+00:00'),
             'Setup sitemap with Symfony',
             GoogleNewsUrlDecorator::ACCESS_REGISTRATION,
             ['Blog', 'Tech'],

--- a/Tests/Unit/Sitemap/Url/GoogleVideoTest.php
+++ b/Tests/Unit/Sitemap/Url/GoogleVideoTest.php
@@ -158,7 +158,7 @@ final class GoogleVideoTest extends TestCase
     public function toXml(): \Generator
     {
         yield [
-            '<video:video><video:thumbnail_loc>http://acme.com/video/thumbnail.jpg</video:thumbnail_loc><video:title><![CDATA[Acme video]]></video:title><video:description><![CDATA[An acme video for testing purposes]]></video:description><video:category><![CDATA[Awesome Cats]]></video:category><video:content_loc>http://acme.com/video/content.flv</video:content_loc><video:duration>600</video:duration><video:rating>4.2</video:rating><video:view_count>42</video:view_count><video:family_friendly>yes</video:family_friendly><video:requires_subscription>yes</video:requires_subscription><video:live>no</video:live><video:expiration_date>2030-01-01T10:00:00+01:00</video:expiration_date><video:publication_date>2020-01-01T10:00:00+01:00</video:publication_date><video:player_loc allow_embed="no" autoplay="ap=1">http://acme.com/video/player.swf?a=b&amp;c=d</video:player_loc><video:restriction relationship="allow">FR BE</video:restriction><video:restriction relationship="deny">GB</video:restriction><video:gallery_loc title="Gallery for testing purposes">http://acme.com/video/gallery/?p=1&amp;sort=desc</video:gallery_loc><video:uploader info="http://acme.com/video/users/1/">depely</video:uploader><video:platform relationship="allow">web mobile</video:platform></video:video>',
+            '<video:video><video:thumbnail_loc>http://acme.com/video/thumbnail.jpg</video:thumbnail_loc><video:title><![CDATA[Acme video]]></video:title><video:description><![CDATA[An acme video for testing purposes]]></video:description><video:category><![CDATA[Awesome Cats]]></video:category><video:content_loc>http://acme.com/video/content.flv</video:content_loc><video:duration>600</video:duration><video:rating>4.2</video:rating><video:view_count>42</video:view_count><video:family_friendly>yes</video:family_friendly><video:requires_subscription>yes</video:requires_subscription><video:live>no</video:live><video:expiration_date>2030-01-01T10:00:00+00:00</video:expiration_date><video:publication_date>2020-01-01T10:00:00+00:00</video:publication_date><video:player_loc allow_embed="no" autoplay="ap=1">http://acme.com/video/player.swf?a=b&amp;c=d</video:player_loc><video:restriction relationship="allow">FR BE</video:restriction><video:restriction relationship="deny">GB</video:restriction><video:gallery_loc title="Gallery for testing purposes">http://acme.com/video/gallery/?p=1&amp;sort=desc</video:gallery_loc><video:uploader info="http://acme.com/video/users/1/">depely</video:uploader><video:platform relationship="allow">web mobile</video:platform></video:video>',
             'http://acme.com/video/thumbnail.jpg',
             'Acme video',
             'An acme video for testing purposes',
@@ -168,10 +168,10 @@ final class GoogleVideoTest extends TestCase
                 'player_location_allow_embed' => GoogleVideo::PLAYER_LOC_ALLOW_EMBED_NO,
                 'player_location_autoplay'    => 'ap=1',
                 'duration'                    => '600',
-                'expiration_date'             => new \DateTime('2030-01-01 10:00:00'),
+                'expiration_date'             => new \DateTime('2030-01-01T10:00:00+00:00'),
                 'rating'                      => 4.2,
                 'view_count'                  => 42,
-                'publication_date'            => new \DateTime('2020-01-01 10:00:00'),
+                'publication_date'            => new \DateTime('2020-01-01T10:00:00+00:00'),
                 'family_friendly'             => GoogleVideo::FAMILY_FRIENDLY_YES,
                 'category'                    => 'Awesome Cats',
                 'restriction_allow'           => ['FR', 'BE'],
@@ -206,7 +206,7 @@ final class GoogleVideoTest extends TestCase
     public function toXmlLegacy(): \Generator
     {
         yield [
-            '<video:video><video:thumbnail_loc>http://acme.com/video/thumbnail.jpg</video:thumbnail_loc><video:title><![CDATA[Acme video]]></video:title><video:description><![CDATA[An acme video for testing purposes]]></video:description><video:category><![CDATA[Awesome Cats]]></video:category><video:content_loc>http://acme.com/video/content.flv</video:content_loc><video:duration>600</video:duration><video:rating>4.2</video:rating><video:view_count>42</video:view_count><video:family_friendly>yes</video:family_friendly><video:requires_subscription>yes</video:requires_subscription><video:live>no</video:live><video:expiration_date>2030-01-01T10:00:00+01:00</video:expiration_date><video:publication_date>2020-01-01T10:00:00+01:00</video:publication_date><video:player_loc allow_embed="no" autoplay="ap=1">http://acme.com/video/player.swf?a=b&amp;c=d</video:player_loc><video:restriction relationship="allow">FR BE</video:restriction><video:restriction relationship="deny">GB</video:restriction><video:gallery_loc title="Gallery for testing purposes">http://acme.com/video/gallery/?p=1&amp;sort=desc</video:gallery_loc><video:uploader info="http://acme.com/video/users/1/">depely</video:uploader><video:platform relationship="allow">web mobile</video:platform></video:video>',
+            '<video:video><video:thumbnail_loc>http://acme.com/video/thumbnail.jpg</video:thumbnail_loc><video:title><![CDATA[Acme video]]></video:title><video:description><![CDATA[An acme video for testing purposes]]></video:description><video:category><![CDATA[Awesome Cats]]></video:category><video:content_loc>http://acme.com/video/content.flv</video:content_loc><video:duration>600</video:duration><video:rating>4.2</video:rating><video:view_count>42</video:view_count><video:family_friendly>yes</video:family_friendly><video:requires_subscription>yes</video:requires_subscription><video:live>no</video:live><video:expiration_date>2030-01-01T10:00:00+00:00</video:expiration_date><video:publication_date>2020-01-01T10:00:00+00:00</video:publication_date><video:player_loc allow_embed="no" autoplay="ap=1">http://acme.com/video/player.swf?a=b&amp;c=d</video:player_loc><video:restriction relationship="allow">FR BE</video:restriction><video:restriction relationship="deny">GB</video:restriction><video:gallery_loc title="Gallery for testing purposes">http://acme.com/video/gallery/?p=1&amp;sort=desc</video:gallery_loc><video:uploader info="http://acme.com/video/users/1/">depely</video:uploader><video:platform relationship="allow">web mobile</video:platform></video:video>',
             'http://acme.com/video/thumbnail.jpg',
             'Acme video',
             'An acme video for testing purposes',
@@ -216,10 +216,10 @@ final class GoogleVideoTest extends TestCase
                 'player_loc_allow_embed' => GoogleVideo::PLAYER_LOC_ALLOW_EMBED_NO,
                 'player_loc_autoplay'    => 'ap=1',
                 'duration'               => '600',
-                'expiration_date'        => new \DateTime('2030-01-01 10:00:00'),
+                'expiration_date'        => new \DateTime('2030-01-01T10:00:00+00:00'),
                 'rating'                 => 4.2,
                 'view_count'             => 42,
-                'publication_date'       => new \DateTime('2020-01-01 10:00:00'),
+                'publication_date'       => new \DateTime('2020-01-01T10:00:00+00:00'),
                 'family_friendly'        => GoogleVideo::FAMILY_FRIENDLY_YES,
                 'category'               => 'Awesome Cats',
                 'restriction_allow'      => ['FR', 'BE'],

--- a/Tests/Unit/Sitemap/Url/GoogleVideoTest.php
+++ b/Tests/Unit/Sitemap/Url/GoogleVideoTest.php
@@ -1,0 +1,321 @@
+<?php
+
+namespace Presta\SitemapBundle\Tests\Unit\Sitemap\Url;
+
+use PHPUnit\Framework\TestCase;
+use Presta\SitemapBundle\Exception\GoogleVideoException;
+use Presta\SitemapBundle\Exception\GoogleVideoTagException;
+use Presta\SitemapBundle\Sitemap\Url\GoogleVideo;
+
+final class GoogleVideoTest extends TestCase
+{
+    public function testConstructorRequiresLocation(): void
+    {
+        $this->expectException(GoogleVideoException::class);
+        $this->expectExceptionMessage('The parameter content_location or content_location is required');
+        new GoogleVideo('url', 'title', 'description', []);
+    }
+
+    public function testConstructorRequiresPlatformRelationship(): void
+    {
+        $this->expectException(GoogleVideoException::class);
+        $this->expectExceptionMessage('The parameter platform_relationship is required when platform is set');
+        new GoogleVideo(
+            'url',
+            'title',
+            'description',
+            ['content_location' => 'url', 'platforms' => [GoogleVideo::PLATFORM_WEB]]
+        );
+    }
+
+    public function testPlayerLocationAllowEmbedValues(): void
+    {
+        $this->expectException(GoogleVideoException::class);
+        $this->expectExceptionMessage('The parameter invalid must be a valid player_location_allow_embed. See http://support.google.com/webmasters/bin/answer.py?hl=en&answer=80472#4');
+        new GoogleVideo(
+            'url',
+            'title',
+            'description',
+            ['content_location' => 'url', 'player_location_allow_embed' => 'invalid']
+        );
+    }
+
+    /**
+     * @dataProvider durationValues
+     */
+    public function testDurationValues(int $value): void
+    {
+        $this->expectException(GoogleVideoException::class);
+        $this->expectExceptionMessage("The parameter $value must be a valid duration. See http://support.google.com/webmasters/bin/answer.py?hl=en&answer=80472#4");
+        new GoogleVideo(
+            'url',
+            'title',
+            'description',
+            ['content_location' => 'url', 'duration' => $value]
+        );
+    }
+
+    public function durationValues(): \Generator
+    {
+        yield [-1];
+        yield [28801];
+    }
+
+    /**
+     * @dataProvider ratingValues
+     */
+    public function testRatingValues(int $value): void
+    {
+        $this->expectException(GoogleVideoException::class);
+        $this->expectExceptionMessage("The parameter $value must be a valid rating. See http://support.google.com/webmasters/bin/answer.py?hl=en&answer=80472#4");
+        new GoogleVideo(
+            'url',
+            'title',
+            'description',
+            ['content_location' => 'url', 'rating' => $value]
+        );
+    }
+
+    public function ratingValues(): \Generator
+    {
+        yield [-1];
+        yield [6];
+    }
+
+    public function testFamilyFriendlyValues(): void
+    {
+        $this->expectException(GoogleVideoException::class);
+        $this->expectExceptionMessage('The parameter invalid must be a valid family_friendly. See http://support.google.com/webmasters/bin/answer.py?hl=en&answer=80472#4');
+        new GoogleVideo(
+            'url',
+            'title',
+            'description',
+            ['content_location' => 'url', 'family_friendly' => 'invalid']
+        );
+    }
+
+    public function testFamilyFriendlyDefault(): void
+    {
+        $video = new GoogleVideo(
+            'url',
+            'title',
+            'description',
+            ['content_location' => 'url', 'family_friendly' => null]
+        );
+        self::assertSame(GoogleVideo::FAMILY_FRIENDLY_YES, $video->getFamilyFriendly());
+    }
+
+    public function testCategoryValues(): void
+    {
+        $value = str_pad('String with more than 256 chars', 257, '-');
+        $this->expectException(GoogleVideoException::class);
+        $this->expectExceptionMessage("The parameter $value must be a valid category. See http://support.google.com/webmasters/bin/answer.py?hl=en&answer=80472#4");
+        new GoogleVideo(
+            'url',
+            'title',
+            'description',
+            ['content_location' => 'url', 'category' => $value]
+        );
+    }
+
+    public function testRequiresSubscriptionValues(): void
+    {
+        $this->expectException(GoogleVideoException::class);
+        $this->expectExceptionMessage('The parameter invalid must be a valid requires_subscription. See http://support.google.com/webmasters/bin/answer.py?hl=en&answer=80472#4');
+        new GoogleVideo(
+            'url',
+            'title',
+            'description',
+            ['content_location' => 'url', 'requires_subscription' => 'invalid']
+        );
+    }
+
+    public function testTagCountLimit(): void
+    {
+        $this->expectException(GoogleVideoTagException::class);
+        $this->expectExceptionMessage('The tags limit of 32 items is exceeded.');
+        $video = new GoogleVideo('url', 'title', 'description', ['content_location' => 'url']);
+        $count = 1;
+        do {
+            $video->addTag("Tag #$count");
+        } while(++$count <= 33);
+    }
+
+    /**
+     * @dataProvider toXml
+     */
+    public function testToXml(
+        string $expectedXml,
+        string $thumbnail,
+        string $title,
+        string $description,
+        array $parameters
+    ): void {
+        $video = new GoogleVideo($thumbnail, $title, $description, $parameters);
+        self::assertSame($expectedXml, $video->toXml());
+    }
+
+    public function toXml(): \Generator
+    {
+        yield [
+            '<video:video><video:thumbnail_loc>http://acme.com/video/thumbnail.jpg</video:thumbnail_loc><video:title><![CDATA[Acme video]]></video:title><video:description><![CDATA[An acme video for testing purposes]]></video:description><video:category><![CDATA[Awesome Cats]]></video:category><video:content_loc>http://acme.com/video/content.flv</video:content_loc><video:duration>600</video:duration><video:rating>4.2</video:rating><video:view_count>42</video:view_count><video:family_friendly>yes</video:family_friendly><video:requires_subscription>yes</video:requires_subscription><video:live>no</video:live><video:expiration_date>2030-01-01T10:00:00+01:00</video:expiration_date><video:publication_date>2020-01-01T10:00:00+01:00</video:publication_date><video:player_loc allow_embed="no" autoplay="ap=1">http://acme.com/video/player.swf?a=b&amp;c=d</video:player_loc><video:restriction relationship="allow">FR BE</video:restriction><video:restriction relationship="deny">GB</video:restriction><video:gallery_loc title="Gallery for testing purposes">http://acme.com/video/gallery/?p=1&amp;sort=desc</video:gallery_loc><video:uploader info="http://acme.com/video/users/1/">depely</video:uploader><video:platform relationship="allow">web mobile</video:platform></video:video>',
+            'http://acme.com/video/thumbnail.jpg',
+            'Acme video',
+            'An acme video for testing purposes',
+            [
+                'content_location'            => 'http://acme.com/video/content.flv',
+                'player_location'             => 'http://acme.com/video/player.swf?a=b&c=d',
+                'player_location_allow_embed' => GoogleVideo::PLAYER_LOC_ALLOW_EMBED_NO,
+                'player_location_autoplay'    => 'ap=1',
+                'duration'                    => '600',
+                'expiration_date'             => new \DateTime('2030-01-01 10:00:00'),
+                'rating'                      => 4.2,
+                'view_count'                  => 42,
+                'publication_date'            => new \DateTime('2020-01-01 10:00:00'),
+                'family_friendly'             => GoogleVideo::FAMILY_FRIENDLY_YES,
+                'category'                    => 'Awesome Cats',
+                'restriction_allow'           => ['FR', 'BE'],
+                'restriction_deny'            => ['GB'],
+                'gallery_location'            => 'http://acme.com/video/gallery/?p=1&sort=desc',
+                'gallery_location_title'      => 'Gallery for testing purposes',
+                'requires_subscription'       => GoogleVideo::REQUIRES_SUBSCRIPTION_YES,
+                'uploader'                    => 'depely',
+                'uploader_info'               => 'http://acme.com/video/users/1/',
+                'platforms'                   => [GoogleVideo::PLATFORM_WEB, GoogleVideo::PLATFORM_MOBILE],
+                'platform_relationship'       => GoogleVideo::PLATFORM_RELATIONSHIP_ALLOW,
+                'live'                        => GoogleVideo::LIVE_NO,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider toXmlLegacy
+     * @group legacy
+     */
+    public function testToXmlLegacy(
+        string $expectedXml,
+        string $thumbnail,
+        string $title,
+        string $description,
+        array $parameters
+    ): void {
+        $video = new GoogleVideo($thumbnail, $title, $description, $parameters);
+        self::assertSame($expectedXml, $video->toXml());
+    }
+
+    public function toXmlLegacy(): \Generator
+    {
+        yield [
+            '<video:video><video:thumbnail_loc>http://acme.com/video/thumbnail.jpg</video:thumbnail_loc><video:title><![CDATA[Acme video]]></video:title><video:description><![CDATA[An acme video for testing purposes]]></video:description><video:category><![CDATA[Awesome Cats]]></video:category><video:content_loc>http://acme.com/video/content.flv</video:content_loc><video:duration>600</video:duration><video:rating>4.2</video:rating><video:view_count>42</video:view_count><video:family_friendly>yes</video:family_friendly><video:requires_subscription>yes</video:requires_subscription><video:live>no</video:live><video:expiration_date>2030-01-01T10:00:00+01:00</video:expiration_date><video:publication_date>2020-01-01T10:00:00+01:00</video:publication_date><video:player_loc allow_embed="no" autoplay="ap=1">http://acme.com/video/player.swf?a=b&amp;c=d</video:player_loc><video:restriction relationship="allow">FR BE</video:restriction><video:restriction relationship="deny">GB</video:restriction><video:gallery_loc title="Gallery for testing purposes">http://acme.com/video/gallery/?p=1&amp;sort=desc</video:gallery_loc><video:uploader info="http://acme.com/video/users/1/">depely</video:uploader><video:platform relationship="allow">web mobile</video:platform></video:video>',
+            'http://acme.com/video/thumbnail.jpg',
+            'Acme video',
+            'An acme video for testing purposes',
+            [
+                'content_loc'            => 'http://acme.com/video/content.flv',
+                'player_loc'             => 'http://acme.com/video/player.swf?a=b&c=d',
+                'player_loc_allow_embed' => GoogleVideo::PLAYER_LOC_ALLOW_EMBED_NO,
+                'player_loc_autoplay'    => 'ap=1',
+                'duration'               => '600',
+                'expiration_date'        => new \DateTime('2030-01-01 10:00:00'),
+                'rating'                 => 4.2,
+                'view_count'             => 42,
+                'publication_date'       => new \DateTime('2020-01-01 10:00:00'),
+                'family_friendly'        => GoogleVideo::FAMILY_FRIENDLY_YES,
+                'category'               => 'Awesome Cats',
+                'restriction_allow'      => ['FR', 'BE'],
+                'restriction_deny'       => ['GB'],
+                'gallery_loc'            => 'http://acme.com/video/gallery/?p=1&sort=desc',
+                'gallery_loc_title'      => 'Gallery for testing purposes',
+                'requires_subscription'  => GoogleVideo::REQUIRES_SUBSCRIPTION_YES,
+                'uploader'               => 'depely',
+                'uploader_info'          => 'http://acme.com/video/users/1/',
+                'platforms'              => [GoogleVideo::PLATFORM_WEB, GoogleVideo::PLATFORM_MOBILE],
+                'platform_relationship'  => GoogleVideo::PLATFORM_RELATIONSHIP_ALLOW,
+                'live'                   => GoogleVideo::LIVE_NO,
+            ],
+        ];
+    }
+
+    /**
+     * Assert that developers that have extends GoogleVideo
+     * and use old named attributes still has functional code with deprecations.
+     *
+     * @group legacy
+     */
+    public function testLegacyAccessors(): void
+    {
+        $video = new class('thumbnail', 'title', 'description', ['content_loc' => 'override later'])
+            extends GoogleVideo {
+
+            public function getThumbnailLocLegacy()
+            {
+                return $this->thumbnail_loc;
+            }
+
+            public function getContentLocLegacy()
+            {
+                return $this->content_loc;
+            }
+
+            public function getPlayerLocLegacy()
+            {
+                return $this->player_loc;
+            }
+
+            public function getPlayerLocAllowEmbedLegacy()
+            {
+                return $this->player_loc_allow_embed;
+            }
+
+            public function getPlayerLocAutoplayLegacy()
+            {
+                return $this->player_loc_autoplay;
+            }
+
+            public function getGalleryLocLegacy()
+            {
+                return $this->gallery_loc;
+            }
+
+            public function getGalleryLocTitleLegacy()
+            {
+                return $this->gallery_loc_title;
+            }
+        };
+
+        $video->setThumbnailLoc('http://acme.com/video/thumbnail.jpg');
+        self::assertSame('http://acme.com/video/thumbnail.jpg', $video->getThumbnailLoc());
+        self::assertSame('http://acme.com/video/thumbnail.jpg', $video->getThumbnailLocLegacy());
+        self::assertSame('http://acme.com/video/thumbnail.jpg', $video->getThumbnailLocation());
+
+        $video->setContentLoc('http://acme.com/video/content.flv');
+        self::assertSame('http://acme.com/video/content.flv', $video->getContentLoc());
+        self::assertSame('http://acme.com/video/content.flv', $video->getContentLocLegacy());
+        self::assertSame('http://acme.com/video/content.flv', $video->getContentLocation());
+
+        $video->setPlayerLoc('http://acme.com/video/player.swf?a=b&c=d');
+        self::assertSame('http://acme.com/video/player.swf?a=b&c=d', $video->getPlayerLoc());
+        self::assertSame('http://acme.com/video/player.swf?a=b&c=d', $video->getPlayerLocLegacy());
+        self::assertSame('http://acme.com/video/player.swf?a=b&c=d', $video->getPlayerLocation());
+
+        $video->setPlayerLocAllowEmbed(GoogleVideo::PLAYER_LOC_ALLOW_EMBED_NO);
+        self::assertSame(GoogleVideo::PLAYER_LOC_ALLOW_EMBED_NO, $video->getPlayerLocAllowEmbed());
+        self::assertSame(GoogleVideo::PLAYER_LOC_ALLOW_EMBED_NO, $video->getPlayerLocAllowEmbedLegacy());
+        self::assertSame(GoogleVideo::PLAYER_LOC_ALLOW_EMBED_NO, $video->getPlayerLocationAllowEmbed());
+
+        $video->setPlayerLocAutoplay('ap=1');
+        self::assertSame('ap=1', $video->getPlayerLocAutoplay());
+        self::assertSame('ap=1', $video->getPlayerLocAutoplayLegacy());
+        self::assertSame('ap=1', $video->getPlayerLocationAutoplay());
+
+        $video->setGalleryLoc('http://acme.com/video/gallery/?p=1&sort=desc');
+        self::assertSame('http://acme.com/video/gallery/?p=1&sort=desc', $video->getGalleryLoc());
+        self::assertSame('http://acme.com/video/gallery/?p=1&sort=desc', $video->getGalleryLocLegacy());
+        self::assertSame('http://acme.com/video/gallery/?p=1&sort=desc', $video->getGalleryLocation());
+
+        $video->setGalleryLocTitle('Gallery for testing purposes');
+        self::assertSame('Gallery for testing purposes', $video->getGalleryLocTitle());
+        self::assertSame('Gallery for testing purposes', $video->getGalleryLocTitleLegacy());
+        self::assertSame('Gallery for testing purposes', $video->getGalleryLocationTitle());
+    }
+}

--- a/Tests/Unit/Sitemap/Url/GoogleVideoTest.php
+++ b/Tests/Unit/Sitemap/Url/GoogleVideoTest.php
@@ -252,9 +252,19 @@ final class GoogleVideoTest extends TestCase
                 return $this->thumbnail_loc;
             }
 
+            public function setThumbnailLocLegacy($value)
+            {
+                $this->thumbnail_loc = $value;
+            }
+
             public function getContentLocLegacy()
             {
                 return $this->content_loc;
+            }
+
+            public function setContentLocLegacy($value)
+            {
+                $this->content_loc = $value;
             }
 
             public function getPlayerLocLegacy()
@@ -262,9 +272,19 @@ final class GoogleVideoTest extends TestCase
                 return $this->player_loc;
             }
 
+            public function setPlayerLocLegacy($value)
+            {
+                $this->player_loc = $value;
+            }
+
             public function getPlayerLocAllowEmbedLegacy()
             {
                 return $this->player_loc_allow_embed;
+            }
+
+            public function setPlayerLocAllowEmbedLegacy($value)
+            {
+                $this->player_loc_allow_embed = $value;
             }
 
             public function getPlayerLocAutoplayLegacy()
@@ -272,14 +292,29 @@ final class GoogleVideoTest extends TestCase
                 return $this->player_loc_autoplay;
             }
 
+            public function setPlayerLocAutoplayLegacy($value)
+            {
+                $this->player_loc_autoplay = $value;
+            }
+
             public function getGalleryLocLegacy()
             {
                 return $this->gallery_loc;
             }
 
+            public function setGalleryLocLegacy($value)
+            {
+                $this->gallery_loc = $value;
+            }
+
             public function getGalleryLocTitleLegacy()
             {
                 return $this->gallery_loc_title;
+            }
+
+            public function setGalleryLocTitleLegacy($value)
+            {
+                $this->gallery_loc_title = $value;
             }
         };
 
@@ -287,35 +322,63 @@ final class GoogleVideoTest extends TestCase
         self::assertSame('http://acme.com/video/thumbnail.jpg', $video->getThumbnailLoc());
         self::assertSame('http://acme.com/video/thumbnail.jpg', $video->getThumbnailLocLegacy());
         self::assertSame('http://acme.com/video/thumbnail.jpg', $video->getThumbnailLocation());
+        $video->setThumbnailLocLegacy('http://legacy.acme.com/video/thumbnail.jpg');
+        self::assertSame('http://legacy.acme.com/video/thumbnail.jpg', $video->getThumbnailLoc());
+        self::assertSame('http://legacy.acme.com/video/thumbnail.jpg', $video->getThumbnailLocLegacy());
+        self::assertSame('http://legacy.acme.com/video/thumbnail.jpg', $video->getThumbnailLocation());
 
         $video->setContentLoc('http://acme.com/video/content.flv');
         self::assertSame('http://acme.com/video/content.flv', $video->getContentLoc());
         self::assertSame('http://acme.com/video/content.flv', $video->getContentLocLegacy());
         self::assertSame('http://acme.com/video/content.flv', $video->getContentLocation());
+        $video->setContentLocLegacy('http://legacy.acme.com/video/content.flv');
+        self::assertSame('http://legacy.acme.com/video/content.flv', $video->getContentLoc());
+        self::assertSame('http://legacy.acme.com/video/content.flv', $video->getContentLocLegacy());
+        self::assertSame('http://legacy.acme.com/video/content.flv', $video->getContentLocation());
 
         $video->setPlayerLoc('http://acme.com/video/player.swf?a=b&c=d');
         self::assertSame('http://acme.com/video/player.swf?a=b&c=d', $video->getPlayerLoc());
         self::assertSame('http://acme.com/video/player.swf?a=b&c=d', $video->getPlayerLocLegacy());
         self::assertSame('http://acme.com/video/player.swf?a=b&c=d', $video->getPlayerLocation());
+        $video->setPlayerLocLegacy('http://legacy.acme.com/video/player.swf?a=b&c=d');
+        self::assertSame('http://legacy.acme.com/video/player.swf?a=b&c=d', $video->getPlayerLoc());
+        self::assertSame('http://legacy.acme.com/video/player.swf?a=b&c=d', $video->getPlayerLocLegacy());
+        self::assertSame('http://legacy.acme.com/video/player.swf?a=b&c=d', $video->getPlayerLocation());
 
         $video->setPlayerLocAllowEmbed(GoogleVideo::PLAYER_LOC_ALLOW_EMBED_NO);
         self::assertSame(GoogleVideo::PLAYER_LOC_ALLOW_EMBED_NO, $video->getPlayerLocAllowEmbed());
         self::assertSame(GoogleVideo::PLAYER_LOC_ALLOW_EMBED_NO, $video->getPlayerLocAllowEmbedLegacy());
         self::assertSame(GoogleVideo::PLAYER_LOC_ALLOW_EMBED_NO, $video->getPlayerLocationAllowEmbed());
+        $video->setPlayerLocAllowEmbedLegacy(GoogleVideo::PLAYER_LOC_ALLOW_EMBED_YES);
+        self::assertSame(GoogleVideo::PLAYER_LOC_ALLOW_EMBED_YES, $video->getPlayerLocAllowEmbed());
+        self::assertSame(GoogleVideo::PLAYER_LOC_ALLOW_EMBED_YES, $video->getPlayerLocAllowEmbedLegacy());
+        self::assertSame(GoogleVideo::PLAYER_LOC_ALLOW_EMBED_YES, $video->getPlayerLocationAllowEmbed());
 
         $video->setPlayerLocAutoplay('ap=1');
         self::assertSame('ap=1', $video->getPlayerLocAutoplay());
         self::assertSame('ap=1', $video->getPlayerLocAutoplayLegacy());
         self::assertSame('ap=1', $video->getPlayerLocationAutoplay());
+        $video->setPlayerLocAutoplayLegacy('legacy=1');
+        self::assertSame('legacy=1', $video->getPlayerLocAutoplay());
+        self::assertSame('legacy=1', $video->getPlayerLocAutoplayLegacy());
+        self::assertSame('legacy=1', $video->getPlayerLocationAutoplay());
 
         $video->setGalleryLoc('http://acme.com/video/gallery/?p=1&sort=desc');
         self::assertSame('http://acme.com/video/gallery/?p=1&sort=desc', $video->getGalleryLoc());
         self::assertSame('http://acme.com/video/gallery/?p=1&sort=desc', $video->getGalleryLocLegacy());
         self::assertSame('http://acme.com/video/gallery/?p=1&sort=desc', $video->getGalleryLocation());
+        $video->setGalleryLocLegacy('http://legacy.acme.com/video/gallery/?p=1&sort=desc');
+        self::assertSame('http://legacy.acme.com/video/gallery/?p=1&sort=desc', $video->getGalleryLoc());
+        self::assertSame('http://legacy.acme.com/video/gallery/?p=1&sort=desc', $video->getGalleryLocLegacy());
+        self::assertSame('http://legacy.acme.com/video/gallery/?p=1&sort=desc', $video->getGalleryLocation());
 
         $video->setGalleryLocTitle('Gallery for testing purposes');
         self::assertSame('Gallery for testing purposes', $video->getGalleryLocTitle());
         self::assertSame('Gallery for testing purposes', $video->getGalleryLocTitleLegacy());
         self::assertSame('Gallery for testing purposes', $video->getGalleryLocationTitle());
+        $video->setGalleryLocTitleLegacy('Legacy Test Gallery');
+        self::assertSame('Legacy Test Gallery', $video->getGalleryLocTitle());
+        self::assertSame('Legacy Test Gallery', $video->getGalleryLocTitleLegacy());
+        self::assertSame('Legacy Test Gallery', $video->getGalleryLocationTitle());
     }
 }

--- a/Tests/Unit/Sitemap/Url/GoogleVideoUrlDecoratorTest.php
+++ b/Tests/Unit/Sitemap/Url/GoogleVideoUrlDecoratorTest.php
@@ -13,8 +13,8 @@ namespace Presta\SitemapBundle\Tests\Unit\Sitemap\Url;
 
 use PHPUnit\Framework\TestCase;
 use Presta\SitemapBundle\Exception\GoogleVideoException;
+use Presta\SitemapBundle\Exception\GoogleVideoUrlException;
 use Presta\SitemapBundle\Sitemap\Url\GoogleVideo;
-use Presta\SitemapBundle\Sitemap\Url\GoogleVideoUrl;
 use Presta\SitemapBundle\Sitemap\Url\GoogleVideoUrlDecorator;
 use Presta\SitemapBundle\Sitemap\Url\UrlConcrete;
 
@@ -37,25 +37,25 @@ class GoogleVideoUrlDecoratorTest extends TestCase
                 "Acme video $i",
                 "An acme video for testing purposes ($i)",
                 [
-                    'content_loc'   => "http://acme.com/video/content$i.flv",
-                    'player_loc'    => 'http://acme.com/video/player.swf?a=b&c=d',
-                    'duration'      => '600',
-                    'expiration_date'   => new \DateTime,
-                    'rating'        => 4.2,
-                    'view_count'    => 42,
-                    'publication_date'  => new \DateTime,
-                    'family_friendly'   => GoogleVideo::FAMILY_FRIENDLY_YES,
-                    'category'          => 'Testing w/ spécial chars',
-                    'restriction_allow' => ['FR', 'BE'],
-                    'restriction_deny'  => ['GB'],
-                    'gallery_loc'       => 'http://acme.com/video/gallery/?p=1&sort=desc',
-                    'gallery_loc_title' => 'Gallery for testing purposes',
-                    'requires_subscription' => GoogleVideo::REQUIRES_SUBSCRIPTION_YES,
-                    'uploader'          => 'depely',
-                    'uploader_info'     => 'http://acme.com/video/users/1/',
-                    'platforms'         => [GoogleVideo::PLATFORM_WEB, GoogleVideo::PLATFORM_MOBILE],
-                    'platform_relationship' => GoogleVideo::PLATFORM_RELATIONSHIP_ALLOW,
-                    'live'              => GoogleVideo::LIVE_NO,
+                    'content_location'       => "http://acme.com/video/content$i.flv",
+                    'player_location'        => 'http://acme.com/video/player.swf?a=b&c=d',
+                    'duration'               => '600',
+                    'expiration_date'        => new \DateTime(),
+                    'rating'                 => 4.2,
+                    'view_count'             => 42,
+                    'publication_date'       => new \DateTime(),
+                    'family_friendly'        => GoogleVideo::FAMILY_FRIENDLY_YES,
+                    'category'               => 'Testing w/ spécial chars',
+                    'restriction_allow'      => ['FR', 'BE'],
+                    'restriction_deny'       => ['GB'],
+                    'gallery_location'       => 'http://acme.com/video/gallery/?p=1&sort=desc',
+                    'gallery_location_title' => 'Gallery for testing purposes',
+                    'requires_subscription'  => GoogleVideo::REQUIRES_SUBSCRIPTION_YES,
+                    'uploader'               => 'depely',
+                    'uploader_info'          => 'http://acme.com/video/users/1/',
+                    'platforms'              => [GoogleVideo::PLATFORM_WEB, GoogleVideo::PLATFORM_MOBILE],
+                    'platform_relationship'  => GoogleVideo::PLATFORM_RELATIONSHIP_ALLOW,
+                    'live'                   => GoogleVideo::LIVE_NO,
                 ]
             );
 
@@ -105,7 +105,7 @@ class GoogleVideoUrlDecoratorTest extends TestCase
             'http://acme.com/video/thumbnail.jpg',
             'Acme video',
             'An acme video for testing purposes',
-            ['content_loc' => 'http://acme.com/video/content.flv']
+            ['content_location' => 'http://acme.com/video/content.flv']
         );
 
         for ($i=0; $i<1000; $i++) {
@@ -220,5 +220,149 @@ class GoogleVideoUrlDecoratorTest extends TestCase
 
         $category = $this->xml->getElementsByTagName('category')->item(0)->nodeValue;
         self::assertEquals($category, 'Testing w/ spécial chars');
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testAccessorsLegacyRequiresConstruct(): void
+    {
+        $this->expectException(GoogleVideoUrlException::class);
+        $this->expectExceptionMessage('thumnail_loc, title and description must be set');
+        $url = new GoogleVideoUrlDecorator(new UrlConcrete('http://acme.com'));
+        $url->setThumbnailLoc('http://acme.com/video/thumbnail.jpg');
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testAccessorsLegacy(): void
+    {
+        $url = new UrlConcrete('http://acme.com');
+        $url = new class($url, 'url', 'title', 'description', ['content_location' => 'url'])
+            extends GoogleVideoUrlDecorator {
+
+            public $videos;
+
+            public function addVideo(GoogleVideo $video)
+            {
+                $this->videos[] = $video;
+
+                return parent::addVideo($video);
+            }
+        };
+
+        $url->setThumbnailLoc('http://acme.com/video/thumbnail.jpg');
+        $url->setTitle('Acme video');
+        $url->setDescription('An acme video for testing purposes');
+        $url->setContentLoc('An acme video for testing purposes');
+        $url->setPlayerLoc('http://acme.com/video/player.swf?a=b&c=d');
+        $url->setPlayerLocAllowEmbed(GoogleVideo::PLAYER_LOC_ALLOW_EMBED_NO);
+        $url->setPlayerLocAutoplay('ap=1');
+        $url->setDuration('600');
+        $url->setExpirationDate(new \DateTime('2030-01-01 10:00:00'));
+        $url->setRating(4.2);
+        $url->setViewCount(42);
+        $url->setPublicationDate(new \DateTime('2020-01-01 10:00:00'));
+        $url->setFamilyFriendly(GoogleVideo::FAMILY_FRIENDLY_YES);
+        $url->setCategory('Awesome Cats');
+        $url->setRestrictionAllow(['FR', 'BE']);
+        $url->setRestrictionDeny(['GB']);
+        $url->setGalleryLoc('http://acme.com/video/gallery/?p=1&sort=desc');
+        $url->setGalleryLocTitle('Gallery for testing purposes');
+        $url->setRequiresSubscription(GoogleVideo::REQUIRES_SUBSCRIPTION_YES);
+        $url->setUploader('depely');
+        $url->setUploaderInfo('http://acme.com/video/users/1/');
+        $url->setPlatforms([GoogleVideo::PLATFORM_WEB, GoogleVideo::PLATFORM_MOBILE]);
+        $url->setPlatformRelationship(GoogleVideo::PLATFORM_RELATIONSHIP_ALLOW);
+        $url->setLive(GoogleVideo::LIVE_NO);
+        $url->addTag('cat');
+        $url->addTag('cute');
+        $url->addPrice(10, 'EUR');
+        $url->addPrice(12, 'USD');
+
+        $url->toXml(); //default video is added here
+        /** @var GoogleVideo $video */
+        $video = $url->videos[0];
+
+        self::assertSame('http://acme.com/video/thumbnail.jpg', $url->getThumbnailLoc());
+        self::assertSame('http://acme.com/video/thumbnail.jpg', $video->getThumbnailLocation());
+
+        self::assertSame('Acme video', $url->getTitle());
+        self::assertSame('Acme video', $video->getTitle());
+
+        self::assertSame('An acme video for testing purposes', $url->getDescription());
+        self::assertSame('An acme video for testing purposes', $video->getDescription());
+
+        self::assertSame('An acme video for testing purposes', $url->getContentLoc());
+        self::assertSame('An acme video for testing purposes', $video->getContentLocation());
+
+        self::assertSame('http://acme.com/video/player.swf?a=b&c=d', $url->getPlayerLoc());
+        self::assertSame('http://acme.com/video/player.swf?a=b&c=d', $video->getPlayerLocation());
+
+        self::assertSame(GoogleVideo::PLAYER_LOC_ALLOW_EMBED_NO, $url->getPlayerLocAllowEmbed());
+        self::assertSame(GoogleVideo::PLAYER_LOC_ALLOW_EMBED_NO, $video->getPlayerLocationAllowEmbed());
+
+        self::assertSame('ap=1', $url->getPlayerLocAutoplay());
+        self::assertSame('ap=1', $video->getPlayerLocationAutoplay());
+
+        self::assertSame('600', $url->getDuration());
+        self::assertSame('600', $video->getDuration());
+
+        self::assertEquals(new \DateTime('2030-01-01 10:00:00'), $url->getExpirationDate());
+        self::assertEquals(new \DateTime('2030-01-01 10:00:00'), $video->getExpirationDate());
+
+        self::assertSame(4.2, $url->getRating());
+        self::assertSame(4.2, $video->getRating());
+
+        self::assertSame(42, $url->getViewCount());
+        self::assertSame(42, $video->getViewCount());
+
+        self::assertEquals(new \DateTime('2020-01-01 10:00:00'), $url->getPublicationDate());
+        self::assertEquals(new \DateTime('2020-01-01 10:00:00'), $video->getPublicationDate());
+
+        self::assertSame(GoogleVideo::FAMILY_FRIENDLY_YES, $url->getFamilyFriendly());
+        self::assertSame(GoogleVideo::FAMILY_FRIENDLY_YES, $video->getFamilyFriendly());
+
+        self::assertSame('Awesome Cats', $url->getCategory());
+        self::assertSame('Awesome Cats', $video->getCategory());
+
+        self::assertSame(['FR', 'BE'], $url->getRestrictionAllow());
+        self::assertSame(['FR', 'BE'], $video->getRestrictionAllow());
+
+        self::assertSame(['GB'], $url->getRestrictionDeny());
+        self::assertSame(['GB'], $video->getRestrictionDeny());
+
+        self::assertSame('http://acme.com/video/gallery/?p=1&sort=desc', $url->getGalleryLoc());
+        self::assertSame('http://acme.com/video/gallery/?p=1&sort=desc', $video->getGalleryLocation());
+
+        self::assertSame('Gallery for testing purposes', $url->getGalleryLocTitle());
+        self::assertSame('Gallery for testing purposes', $video->getGalleryLocationTitle());
+
+        self::assertSame(GoogleVideo::REQUIRES_SUBSCRIPTION_YES, $url->getRequiresSubscription());
+        self::assertSame(GoogleVideo::REQUIRES_SUBSCRIPTION_YES, $video->getRequiresSubscription());
+
+        self::assertSame('depely', $url->getUploader());
+        self::assertSame('depely', $video->getUploader());
+
+        self::assertSame('http://acme.com/video/users/1/', $url->getUploaderInfo());
+        self::assertSame('http://acme.com/video/users/1/', $video->getUploaderInfo());
+
+        self::assertSame([GoogleVideo::PLATFORM_WEB, GoogleVideo::PLATFORM_MOBILE], $url->getPlatforms());
+        self::assertSame([GoogleVideo::PLATFORM_WEB, GoogleVideo::PLATFORM_MOBILE], $video->getPlatforms());
+
+        self::assertSame(GoogleVideo::PLATFORM_RELATIONSHIP_ALLOW, $url->getPlatformRelationship());
+        self::assertSame(GoogleVideo::PLATFORM_RELATIONSHIP_ALLOW, $video->getPlatformRelationship());
+
+        self::assertSame(GoogleVideo::LIVE_NO, $url->getLive());
+        self::assertSame(GoogleVideo::LIVE_NO, $video->getLive());
+
+        self::assertSame(['cat', 'cute'], $url->getTags());
+        self::assertSame(['cat', 'cute'], $video->getTags());
+
+        $eur = ['amount' => 10, 'currency' => 'EUR', 'type' => null, 'resolution' => null];
+        $usd = ['amount' => 12, 'currency' => 'USD', 'type' => null, 'resolution' => null];
+        self::assertSame([$eur, $usd], $url->getPrices());
+        self::assertSame([$eur, $usd], $video->getPrices());
     }
 }

--- a/Tests/Unit/Sitemap/Url/UrlConcreteTest.php
+++ b/Tests/Unit/Sitemap/Url/UrlConcreteTest.php
@@ -133,4 +133,28 @@ class UrlConcreteTest extends TestCase
         yield [1, 1.0];
         yield [1.00, 1.0];
     }
+
+    /**
+     * @dataProvider setInvalidPriorityProvider
+     */
+    public function testSetInvalidPriority($value): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(
+            "The value \"$value\" is not supported by the option priority, it must be a numeric between 0.0 and 1.0." .
+            " See http://www.sitemaps.org/protocol.html#xmlTagDefinitions"
+        );
+
+        $url = new UrlConcrete('http://example.com');
+        $url->setPriority($value);
+    }
+
+    public function setInvalidPriorityProvider(): \Generator
+    {
+        yield [true];
+        yield [-1];
+        yield [-0.01];
+        yield [-2];
+        yield [-1.01];
+    }
 }

--- a/Tests/Unit/Sitemap/UtilsTest.php
+++ b/Tests/Unit/Sitemap/UtilsTest.php
@@ -22,6 +22,9 @@ use Presta\SitemapBundle\Sitemap\Utils;
  */
 class UtilsTest extends TestCase
 {
+    /**
+     * @group legacy
+     */
     public function testGetSetMethodException(): void
     {
         $this->expectException(Exception::class);
@@ -30,6 +33,9 @@ class UtilsTest extends TestCase
         Utils::getSetMethod($object, 'unknown');
     }
 
+    /**
+     * @group legacy
+     */
     public function testGetGetMethodException(): void
     {
         $this->expectException(Exception::class);
@@ -38,9 +44,18 @@ class UtilsTest extends TestCase
         Utils::getGetMethod($object, 'unknown');
     }
 
+    /**
+     * @group legacy
+     */
     public function testRender(): void
     {
         $actual = Utils::render('data w/ cdata section');
+        self::assertEquals('<![CDATA[data w/ cdata section]]>', $actual);
+    }
+
+    public function testCdata(): void
+    {
+        $actual = Utils::cdata('data w/ cdata section');
         self::assertEquals('<![CDATA[data w/ cdata section]]>', $actual);
     }
 
@@ -48,11 +63,5 @@ class UtilsTest extends TestCase
     {
         $actual = Utils::encode('data & spécial chars>');
         self::assertEquals('data &amp; spécial chars&gt;', $actual);
-    }
-
-    public function testCamelize(): void
-    {
-        $actual = Utils::camelize('data to_camelize');
-        self::assertEquals('DataToCamelize', $actual);
     }
 }


### PR DESCRIPTION
This PullRequest rename some of the `Presta\SitemapBundle\Sitemap\Url` classes properties : 

- `GoogleImage::$loc` => `GoogleImage::$location`
- `GoogleImage::$geo_location` => `GoogleImage::$geoLocation`
- `GoogleVideo::$thumbnail_loc` => `GoogleVideo::$thumbnailLocation`
- `GoogleVideo::$content_loc` => `GoogleVideo::$contentLocation`
- `GoogleVideo::$player_loc` => `GoogleVideo::$playerLocation`
- `GoogleVideo::$player_loc_allow_embed` => `GoogleVideo::$playerLocationAllowEmbed`
- `GoogleVideo::$player_loc_autoplay` => `GoogleVideo::$playerLocationAutoplay`
- `GoogleVideo::$expiration_date` => `GoogleVideo::$expirationDate`
- `GoogleVideo::$view_count` => `GoogleVideo::$viewCount`
- `GoogleVideo::$publication_date` => `GoogleVideo::$publicationDate`
- `GoogleVideo::$family_friendly` => `GoogleVideo::$familyFriendly`
- `GoogleVideo::$restriction_allow` => `GoogleVideo::$restrictionAllow`
- `GoogleVideo::$restriction_deny` => `GoogleVideo::$restrictionDeny`
- `GoogleVideo::$gallery_loc` => `GoogleVideo::$galleryLocation`
- `GoogleVideo::$gallery_loc_title` => `GoogleVideo::$galleryLocationTitle`
- `GoogleVideo::$requires_subscription` => `GoogleVideo::$requiresSubscription`
- `GoogleVideo::$uploader_info` => `GoogleVideo::$uploaderInformation`
- `GoogleVideo::$platform_relationship` => `GoogleVideo::$platformRelationship`

> **Why :** We really want to add some code style/quality/type automation, and those properties don't fit our standards : 
> - underscore_case instead of camelCase
> - usage of short names : loc instead of location

-----

This PullRequest also add more tests to `Presta\SitemapBundle\Sitemap\Url` classes :

- `GoogleImageTest` : Legacy properties accessors
- `GoogleImageUrlDecoratorTest` : Increase coverage
- `GoogleNewsUrlDecoratorTest` : Increase coverage
- `GoogleVideoTest` : Increase coverage + Legacy properties accessors
- `GoogleVideoUrlDecoratorTest` : Increase coverage + Legacy properties accessors
- `UrlConcreteTest` : Increase coverage

-----

Finally, this PullRequest deprecates :

- `Utils::getSetMethod`
- `Utils::getGetMethod`
- `Utils::camelize`

> **Why :** These methods were (supposed to be) internal and unused after `GoogleVideo` class refactoring.

And rename : 

- `Utils::render` => `Utils::cdata` (with deprecation on `render` usage)

> **Why :** The method name was not clear enough.
