### PR TITLE
doc(Installation): Use .yaml extension to be understood by Symfony

### DIFF
--- a/Resources/doc/1-installation.md
+++ b/Resources/doc/1-installation.md
@@ -41,7 +41,7 @@ class AppKernel
 Import routing.
 
 ```yaml
-#config/routes/presta_sitemap.yml
+# config/routes/presta_sitemap.yaml
 presta_sitemap:
     resource: "@PrestaSitemapBundle/Resources/config/routing.yml"
 ```


### PR DESCRIPTION
Hi,

I create this very little PR to update "Installation" documentation. In Symfony 5, to makes routes ok, we need to use `.yaml` extension instead of `.yml`.

Thanks for this very practical project,
Bye. 👋 