### PR TITLE
Deprecate cache support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ You may also have a look to [Prestaconcept's website sitemap](https://www.presta
 * Comply with Urlset specifications : 50k items / 10MB per file
 * Decorates your sitemap with images, video, mobile and multilang urls
 * No database required
-* Optional caching (using `DoctrineCacheBundle`)
 
 
 ## Documentation

--- a/Resources/doc/2-configuration.md
+++ b/Resources/doc/2-configuration.md
@@ -56,8 +56,6 @@ presta_sitemap:
     timetolive: 3600
 ```
 
-Also this value is used by the cache if you have installed and configured doctrine_cache.
-
 
 ## Configuring your application base url
 
@@ -103,7 +101,10 @@ presta_sitemap:
 ```
 
 
-## Caching the sitemap
+## Caching the sitemap (deprecated)
+
+> **warning** Cache support has been deprecated since v2.3.2 and will be removed in v3.0.0.
+> Please [dump](6-dumping-sitemap.md) your sitemap instead.
 
 Sitemap can be stored in a cache.
 

--- a/Resources/doc/6-dumping-sitemap.md
+++ b/Resources/doc/6-dumping-sitemap.md
@@ -3,8 +3,7 @@
 Back to the [installation](1-installation.md) instructions, you may have noticed that this bundle is declaring routes:
 `/sitemap.xml` and `/sitemap.{section}.xml`.
 
-That means that, whenever the sitemap is requested, it is built on demand
-(or build from cache if you [configured](2-configuration.md) an adapter for the bundle).
+That means that, whenever the sitemap is requested, it is built on demand.
 
 For small sites, it is fast enough to be a good option.
 But as your site grows (and so your sitemap), this option starts being a very bad one.

--- a/Service/Generator.php
+++ b/Service/Generator.php
@@ -59,6 +59,14 @@ class Generator extends AbstractGenerator implements GeneratorInterface
         $this->router = $router;
         $this->cache = $cache;
         $this->cacheTtl = $cacheTtl;
+
+        if ($cache !== null) {
+            @trigger_error(
+                'Providing ' . __METHOD__ . ' $cache parameter is deprecated.' .
+                ' Cache support has been deprecated since v2.3.2 and will be removed in v3.0.0.',
+                E_USER_DEPRECATED
+            );
+        }
     }
 
     /**
@@ -66,6 +74,12 @@ class Generator extends AbstractGenerator implements GeneratorInterface
      */
     public function generate()
     {
+        @trigger_error(
+            __METHOD__ . ' is deprecated since v2.3.2 and will be removed in v3.0.0.' .
+            ' Use ' . __CLASS__ . '::fetch instead.',
+            E_USER_DEPRECATED
+        );
+
         $this->populate();
 
         //---------------------
@@ -91,7 +105,7 @@ class Generator extends AbstractGenerator implements GeneratorInterface
         }
 
         if ('root' === $name) {
-            $this->generate();
+            $this->populate();
 
             return $this->getRoot();
         }

--- a/Service/GeneratorInterface.php
+++ b/Service/GeneratorInterface.php
@@ -21,16 +21,18 @@ use Presta\SitemapBundle\Sitemap\XmlConstraint;
 interface GeneratorInterface extends UrlContainerInterface
 {
     /**
-     * Generate all datas and store in cache if it is possible
+     * Generate all sitemaps.
+     *
+     * @deprecated since v2.3.2 use @link GeneratorInterface::fetch instead
      */
     public function generate();
 
     /**
-     * Get eventual cached data or generate whole sitemap
+     * Generate sitemap section.
      *
-     * @param string $name
+     * @param string $name The section name (or "root" for all sections)
      *
-     * @return XmlConstraint|null
+     * @return XmlConstraint|null The generated XML (or null if section not found)
      */
     public function fetch($name);
 }

--- a/Tests/Unit/Service/GeneratorTest.php
+++ b/Tests/Unit/Service/GeneratorTest.php
@@ -51,6 +51,9 @@ class GeneratorTest extends WebTestCase
         });
     }
 
+    /**
+     * @group legacy
+     */
     public function testGenerate(): void
     {
         $this->generator()->generate();

--- a/composer.json
+++ b/composer.json
@@ -20,15 +20,11 @@
         "symfony/framework-bundle": "^3.4|~4.0|~5.0"
     },
     "require-dev": {
-        "ext-simplexml": "*",
         "doctrine/annotations": "^1.0",
         "phpunit/phpunit": "^7.5",
         "symfony/browser-kit": "^4.4",
         "symfony/phpunit-bridge": "^4.4",
         "symfony/yaml": "^4.4"
-    },
-    "suggest": {
-        "doctrine/doctrine-cache-bundle" : "Allows to store sitemaps in cache"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
As proposed in #241 this Pull Request deprecates all cache related content, in favor of sitemap dump.

The `Presta\SitemapBundle\Service\GeneratorInterface::generate` method was also deprecated, because it is unused anymore and has no purpose without cache support.