### PR TITLE
Fix .yaml routes configuration 1-installation.md

### DIFF
--- a/doc/1-installation.md
+++ b/doc/1-installation.md
@@ -43,7 +43,7 @@ Import routing.
 ```yaml
 # config/routes/presta_sitemap.yaml
 presta_sitemap:
-    resource: "@PrestaSitemapBundle/config/routing.yml"
+    resource: "@PrestaSitemapBundle/Resources/config/routing.yml"
 ```
 
 > **Note** you may not be required to import routing if you would only rely on dumped sitemaps.


### PR DESCRIPTION
The import had a not valid key config value which would make the endpoints of this library not work.