### PR TITLE
Allow Symfony 6.x in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     "require": {
         "php": ">=7.1.3",
         "ext-simplexml": "*",
-        "symfony/console": "^4.4|^5.0",
-        "symfony/framework-bundle": "^4.4|^5.0"
+        "symfony/console": "^4.4|^5.0|^6.0",
+        "symfony/framework-bundle": "^4.4|^5.0|^6.0"
     },
     "require-dev": {
         "doctrine/annotations": "^1.0",
@@ -25,10 +25,10 @@
         "phpunit/phpunit": "^7.5|^8.0",
         "sensio/framework-extra-bundle": "^5.5|^6.1",
         "squizlabs/php_codesniffer": "^3.5",
-        "symfony/messenger": "^4.4|^5.0",
-        "symfony/browser-kit": "^4.4|^5.0",
-        "symfony/phpunit-bridge": "^4.4|^5.0",
-        "symfony/yaml": "^4.4|^5.0"
+        "symfony/messenger": "^4.4|^5.0|^6.0",
+        "symfony/browser-kit": "^4.4|^5.0|^6.0",
+        "symfony/phpunit-bridge": "^4.4|^5.0|^6.0",
+        "symfony/yaml": "^4.4|^5.0|^6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Missing part of the #291 