### PR TITLE
Allow subscribing events by class

### DIFF
--- a/doc/4-dynamic-routes-usage.md
+++ b/doc/4-dynamic-routes-usage.md
@@ -47,7 +47,7 @@ class SitemapSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            SitemapPopulateEvent::ON_SITEMAP_POPULATE => 'populate',
+            SitemapPopulateEvent::class => 'populate',
         ];
     }
 

--- a/src/DependencyInjection/PrestaSitemapExtension.php
+++ b/src/DependencyInjection/PrestaSitemapExtension.php
@@ -11,6 +11,8 @@
 
 namespace Presta\SitemapBundle\DependencyInjection;
 
+use Presta\SitemapBundle\Event\SitemapAddUrlEvent;
+use Presta\SitemapBundle\Event\SitemapPopulateEvent;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;

--- a/src/Event/SitemapAddUrlEvent.php
+++ b/src/Event/SitemapAddUrlEvent.php
@@ -27,6 +27,7 @@ class SitemapAddUrlEvent extends Event
 {
     /**
      * @Event("Presta\SitemapBundle\Event\SitemapAddUrlEvent")
+     * @deprecated since presta/sitemap-bundle 3.3, use `SitemapAddUrlEvent::class` instead.
      */
     public const NAME = 'presta_sitemap.add_url';
 

--- a/src/Event/SitemapPopulateEvent.php
+++ b/src/Event/SitemapPopulateEvent.php
@@ -26,6 +26,7 @@ class SitemapPopulateEvent extends Event
 {
     /**
      * @Event("Presta\SitemapBundle\Event\SitemapPopulateEvent")
+     * @deprecated since presta/sitemap-bundle 3.3, use `SitemapPopulateEvent::class` instead.
      */
     public const ON_SITEMAP_POPULATE = 'presta_sitemap.populate';
 

--- a/src/EventListener/RouteAnnotationEventListener.php
+++ b/src/EventListener/RouteAnnotationEventListener.php
@@ -59,7 +59,7 @@ class RouteAnnotationEventListener implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            SitemapPopulateEvent::ON_SITEMAP_POPULATE => ['registerRouteAnnotation', 0],
+            SitemapPopulateEvent::class => ['registerRouteAnnotation', 0],
         ];
     }
 

--- a/src/EventListener/StaticRoutesAlternateEventListener.php
+++ b/src/EventListener/StaticRoutesAlternateEventListener.php
@@ -55,7 +55,7 @@ final class StaticRoutesAlternateEventListener implements EventSubscriberInterfa
     public static function getSubscribedEvents(): array
     {
         return [
-            SitemapAddUrlEvent::NAME => 'addAlternate',
+            SitemapAddUrlEvent::class => 'addAlternate',
         ];
     }
 

--- a/src/PrestaSitemapBundle.php
+++ b/src/PrestaSitemapBundle.php
@@ -11,6 +11,11 @@
 
 namespace Presta\SitemapBundle;
 
+use Presta\SitemapBundle\DependencyInjection\Compiler\EventAliasMappingPass;
+use Presta\SitemapBundle\Event\SitemapAddUrlEvent;
+use Presta\SitemapBundle\Event\SitemapPopulateEvent;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\EventDispatcher\DependencyInjection\AddEventAliasesPass;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -20,6 +25,21 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class PrestaSitemapBundle extends Bundle
 {
+    /**
+     * @inheritdoc
+     *
+     * @return void
+     */
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new AddEventAliasesPass([
+            SitemapAddUrlEvent::class => SitemapAddUrlEvent::NAME,
+            SitemapPopulateEvent::class => SitemapPopulateEvent::ON_SITEMAP_POPULATE,
+        ]));
+    }
+
     /**
      * @inheritDoc
      */

--- a/tests/Integration/src/Listener/SitemapListener.php
+++ b/tests/Integration/src/Listener/SitemapListener.php
@@ -20,7 +20,6 @@ use Presta\SitemapBundle\Sitemap\Url\GoogleVideoUrlDecorator;
 use Presta\SitemapBundle\Sitemap\Url\UrlConcrete;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Component\Routing\RouterInterface;
 
 final class SitemapListener implements EventSubscriberInterface
 {
@@ -54,7 +53,7 @@ final class SitemapListener implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            SitemapPopulateEvent::ON_SITEMAP_POPULATE => 'populate',
+            SitemapPopulateEvent::class => 'populate',
         ];
     }
 

--- a/tests/Unit/EventListener/RouteAnnotationEventListenerTest.php
+++ b/tests/Unit/EventListener/RouteAnnotationEventListenerTest.php
@@ -148,7 +148,7 @@ class RouteAnnotationEventListenerTest extends TestCase
         );
 
         $dispatcher->addSubscriber(new RouteAnnotationEventListener($router, $dispatcher, 'default'));
-        $dispatcher->dispatch($event, SitemapPopulateEvent::ON_SITEMAP_POPULATE);
+        $dispatcher->dispatch($event, SitemapPopulateEvent::class);
     }
 
     private function findUrl(array $urlset, string $loc): ?UrlConcrete

--- a/tests/Unit/EventListener/StaticRoutesAlternateEventListenerTest.php
+++ b/tests/Unit/EventListener/StaticRoutesAlternateEventListenerTest.php
@@ -119,7 +119,7 @@ class StaticRoutesAlternateEventListenerTest extends TestCase
         $dispatcher->addSubscriber(new StaticRoutesAlternateEventListener($this->router, $listenerOptions));
 
         $event = new SitemapAddUrlEvent($route, $options);
-        $dispatcher->dispatch($event, SitemapAddUrlEvent::NAME);
+        $dispatcher->dispatch($event, SitemapAddUrlEvent::class);
 
         return $event;
     }


### PR DESCRIPTION
Subscribing by event names was and old way before subscribing by event class name was not supported, so this enables it.
