### PR TITLE
Documentation Incorrect

### DIFF
--- a/doc/4-dynamic-routes-usage.md
+++ b/doc/4-dynamic-routes-usage.md
@@ -56,7 +56,7 @@ class SitemapSubscriber implements EventSubscriberInterface
      */
     public function populate(SitemapPopulateEvent $event): void
     {
-        $this->registerBlogPostsUrls($event->getUrlContainer());
+        $this->registerBlogPostsUrls($event->getUrlContainer(), $event->getUrlGenerator());
     }
 
     /**


### PR DESCRIPTION
The registerBlogPostsUrls() requires two parameters and it is only given one.