### PR TITLE
Fix Symfony 6.2 deprecation

### DIFF
--- a/config/messenger.xml
+++ b/config/messenger.xml
@@ -8,7 +8,7 @@
             <argument type="service" id="router" />
             <argument type="service" id="presta_sitemap.dumper" />
             <argument>%presta_sitemap.dump_directory%</argument>
-            <tag name="messenger.message_handler" />
+            <tag name="messenger.message_handler" handles="Presta\SitemapBundle\Messenger\DumpSitemapMessage" />
         </service>
     </services>
 

--- a/src/DependencyInjection/PrestaSitemapExtension.php
+++ b/src/DependencyInjection/PrestaSitemapExtension.php
@@ -17,7 +17,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
  * Load Bundle configuration, configure container parameters & services.
@@ -51,7 +51,7 @@ class PrestaSitemapExtension extends Extension
             }
         }
 
-        if (interface_exists(MessageHandlerInterface::class)) {
+        if (interface_exists(MessageBusInterface::class)) {
             $loader->load('messenger.xml');
         }
 

--- a/tests/Integration/config/6.2/framework.yaml
+++ b/tests/Integration/config/6.2/framework.yaml
@@ -1,0 +1,14 @@
+framework:
+    test: true
+    secret: '%env(APP_SECRET)%'
+    http_method_override: false
+    session:
+        handler_id: null
+        cookie_secure: auto
+        cookie_samesite: lax
+        storage_factory_id: session.storage.factory.mock_file
+    php_errors:
+        log: true
+    router:
+        utf8: true
+    cache: null

--- a/tests/Integration/config/6.2/messenger.yaml
+++ b/tests/Integration/config/6.2/messenger.yaml
@@ -1,0 +1,6 @@
+framework:
+    messenger:
+        transports:
+            async: 'in-memory://'
+        routing:
+            'Presta\SitemapBundle\Messenger\DumpSitemapMessage': async

--- a/tests/Integration/config/6.2/presta_sitemap.yaml
+++ b/tests/Integration/config/6.2/presta_sitemap.yaml
@@ -1,0 +1,9 @@
+presta_sitemap:
+    default_section: static
+    dump_directory: "%kernel.project_dir%/public"
+    items_by_set: 10
+    alternate:
+        enabled: true
+        default_locale: en
+        locales: [en, fr]
+        i18n: symfony

--- a/tests/Integration/config/6.2/routes/annotations.yaml
+++ b/tests/Integration/config/6.2/routes/annotations.yaml
@@ -1,0 +1,3 @@
+controllers:
+    resource: ../../../src/Controller/
+    type: annotation

--- a/tests/Integration/config/6.2/routes/presta_sitemap.yaml
+++ b/tests/Integration/config/6.2/routes/presta_sitemap.yaml
@@ -1,0 +1,2 @@
+presta_sitemap:
+    resource: "@PrestaSitemapBundle/config/routing.yml"

--- a/tests/Integration/config/6.2/routes/translated.yaml
+++ b/tests/Integration/config/6.2/routes/translated.yaml
@@ -1,0 +1,7 @@
+about:
+  path:
+    en: /about
+    fr: /a-propos
+  defaults: { _controller: \Presta\SitemapBundle\Tests\Integration\Controller\StaticController::about }
+  options:
+    sitemap: true

--- a/tests/Integration/config/6.2/routes/xml.xml
+++ b/tests/Integration/config/6.2/routes/xml.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <route id="xml" path="/company">
+        <default key="_controller">Presta\SitemapBundle\Tests\Integration\Controller\StaticController::company</default>
+        <option key="sitemap">
+            {"priority":"0.7", "changefreq":"weekly", "section":"static"}
+        </option>
+    </route>
+
+</routes>

--- a/tests/Integration/config/6.2/routes/yaml.yaml
+++ b/tests/Integration/config/6.2/routes/yaml.yaml
@@ -1,0 +1,6 @@
+yaml:
+  path: /contact
+  defaults: { _controller: \Presta\SitemapBundle\Tests\Integration\Controller\StaticController::contact }
+  options:
+    sitemap:
+      section: static


### PR DESCRIPTION
When using the bundle with Symfony 6.2 there is this deprecation warning:

`
The "Presta\SitemapBundle\Messenger\DumpSitemapMessageHandler" class implements "Symfony\Component\Messenger\Handler\MessageHandlerInterface" that is deprecated since Symfony 6.2, use the {@see AsMessageHandler} attribute instead.
`

AFAIK the `MessageHandlerInterface` is just a marker to tell Symfony to autoconfigure the class, but since it's already defined and configured in 

https://github.com/prestaconcept/PrestaSitemapBundle/blob/61e6c07606e4a52dfd76a0b754b07e3cdd50e31a/config/messenger.xml#L7-L12

I think the interface is not necessary.

~Technically this is a BC break, but I guess this class is not meant to be extended by the user.~

Update: Following https://github.com/prestaconcept/PrestaSitemapBundle/pull/303#issuecomment-1384860212, it is resolved by adding `handles="Presta\SitemapBundle\Messenger\DumpSitemapMessage"`, there is no need to remove the interface for now.