### PR TITLE
Fix Symfony 6.2 deprecation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,8 @@ jobs:
             symfony-version: 5.4.*
           - php-version: 8.1
             symfony-version: 6.1.*
+          - php-version: 8.2
+            symfony-version: 6.2.*
 
     steps:
       - name: "Checkout"

--- a/config/messenger.xml
+++ b/config/messenger.xml
@@ -8,7 +8,7 @@
             <argument type="service" id="router" />
             <argument type="service" id="presta_sitemap.dumper" />
             <argument>%presta_sitemap.dump_directory%</argument>
-            <tag name="messenger.message_handler" />
+            <tag name="messenger.message_handler" handles="Presta\SitemapBundle\Messenger\DumpSitemapMessage" />
         </service>
     </services>
 

--- a/src/DependencyInjection/PrestaSitemapExtension.php
+++ b/src/DependencyInjection/PrestaSitemapExtension.php
@@ -18,6 +18,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
  * Load Bundle configuration, configure container parameters & services.
@@ -51,7 +52,7 @@ class PrestaSitemapExtension extends Extension
             }
         }
 
-        if (interface_exists(MessageHandlerInterface::class)) {
+        if (interface_exists(MessageBusInterface::class)) {
             $loader->load('messenger.xml');
         }
 

--- a/src/Messenger/DumpSitemapMessageHandler.php
+++ b/src/Messenger/DumpSitemapMessageHandler.php
@@ -13,13 +13,12 @@ namespace Presta\SitemapBundle\Messenger;
 
 use Presta\SitemapBundle\Service\DumperInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
  * Message handler to handle DumpSitemapMessage asynchronously or synchronously in background
  */
-class DumpSitemapMessageHandler implements MessageHandlerInterface
+class DumpSitemapMessageHandler
 {
     /**
      * @var RouterInterface


### PR DESCRIPTION
> The "Presta\SitemapBundle\Messenger\DumpSitemapMessageHandler" class implements "Symfony\Component\Messenger\Handler\MessageHandlerInterface" that is deprecated since Symfony 6.2, use the {@ see AsMessageHandler} attribute instead.