### PR TITLE
Switch latests tests to Symfony 6.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
           - php-version: 8.1
             symfony-version: 5.4.*
           - php-version: 8.1
-            symfony-version: 6.1.*
+            symfony-version: 6.2.*
 
     steps:
       - name: "Checkout"
@@ -56,7 +56,7 @@ jobs:
       matrix:
         include:
           - php-version: 8.1
-            symfony-version: 6.1.*
+            symfony-version: 6.2.*
 
     steps:
       - name: "Checkout"
@@ -95,7 +95,7 @@ jobs:
       matrix:
         include:
           - php-version: 8.1
-            symfony-version: 6.1.*
+            symfony-version: 6.2.*
 
     steps:
       - name: "Checkout"
@@ -128,7 +128,7 @@ jobs:
       matrix:
         include:
           - php-version: 8.1
-            symfony-version: 6.1.*
+            symfony-version: 6.2.*
 
     steps:
       - name: "Checkout"


### PR DESCRIPTION
After merging https://github.com/prestaconcept/PrestaSitemapBundle/pull/303
Updated testing matrix to test on `6.2`