### PR TITLE
Replace event subscribers with event listeners

### DIFF
--- a/config/alternate_listener.xml
+++ b/config/alternate_listener.xml
@@ -7,7 +7,7 @@
         <service id="presta_sitemap.event_listener.static_routes_alternate" class="Presta\SitemapBundle\EventListener\StaticRoutesAlternateEventListener">
             <argument type="service" id="router"/>
             <argument>%presta_sitemap.alternate%</argument>
-            <tag name="kernel.event_subscriber"/>
+            <tag name="kernel.event_listener" event="Presta\SitemapBundle\Event\SitemapAddUrlEvent" method="addAlternate"/>
         </service>
     </services>
 

--- a/config/route_annotation_listener.xml
+++ b/config/route_annotation_listener.xml
@@ -12,7 +12,7 @@
             <argument type="service" id="router"/>
             <argument type="service" id="event_dispatcher"/>
             <argument>%presta_sitemap.default_section%</argument>
-            <tag name="kernel.event_subscriber"/>
+            <tag name="kernel.event_listener" event="Presta\SitemapBundle\Event\SitemapPopulateEvent" method="registerRouteAnnotation"/>
         </service>
     </services>
 

--- a/src/EventListener/RouteAnnotationEventListener.php
+++ b/src/EventListener/RouteAnnotationEventListener.php
@@ -17,7 +17,6 @@ use Presta\SitemapBundle\Routing\RouteOptionParser;
 use Presta\SitemapBundle\Service\UrlContainerInterface;
 use Presta\SitemapBundle\Sitemap\Url\UrlConcrete;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\Exception\MissingMandatoryParametersException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
@@ -28,7 +27,7 @@ use Symfony\Component\Routing\RouterInterface;
  *
  * @phpstan-import-type RouteOptions from RouteOptionParser
  */
-class RouteAnnotationEventListener implements EventSubscriberInterface
+class RouteAnnotationEventListener
 {
     /**
      * @var RouterInterface
@@ -53,16 +52,6 @@ class RouteAnnotationEventListener implements EventSubscriberInterface
         $this->router = $router;
         $this->dispatcher = $eventDispatcher;
         $this->defaultSection = $defaultSection;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public static function getSubscribedEvents(): array
-    {
-        return [
-            SitemapPopulateEvent::class => ['registerRouteAnnotation', 0],
-        ];
     }
 
     /**

--- a/src/EventListener/StaticRoutesAlternateEventListener.php
+++ b/src/EventListener/StaticRoutesAlternateEventListener.php
@@ -14,7 +14,6 @@ namespace Presta\SitemapBundle\EventListener;
 use Presta\SitemapBundle\Event\SitemapAddUrlEvent;
 use Presta\SitemapBundle\Sitemap\Url\GoogleMultilangUrlDecorator;
 use Presta\SitemapBundle\Sitemap\Url\UrlConcrete;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
@@ -28,7 +27,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  *     locales: array<string>
  * }
  */
-final class StaticRoutesAlternateEventListener implements EventSubscriberInterface
+final class StaticRoutesAlternateEventListener
 {
     private const TRANSLATED_ROUTE_NAME_STRATEGIES = [
         'symfony' => '/^(?P<name>.+)\.(?P<locale>%locales%)$/',
@@ -53,16 +52,6 @@ final class StaticRoutesAlternateEventListener implements EventSubscriberInterfa
     {
         $this->router = $router;
         $this->options = $options;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public static function getSubscribedEvents(): array
-    {
-        return [
-            SitemapAddUrlEvent::class => 'addAlternate',
-        ];
     }
 
     public function addAlternate(SitemapAddUrlEvent $event): void

--- a/tests/Unit/DependencyInjection/PrestaSitemapExtensionTest.php
+++ b/tests/Unit/DependencyInjection/PrestaSitemapExtensionTest.php
@@ -27,7 +27,7 @@ use Symfony\Component\Routing\Router;
 class PrestaSitemapExtensionTest extends TestCase
 {
     private const SERVICES = [
-        ['presta_sitemap.eventlistener.route_annotation', 'Static routes listener', 'kernel.event_subscriber'],
+        ['presta_sitemap.eventlistener.route_annotation', 'Static routes listener', 'kernel.event_listener'],
         ['presta_sitemap.controller', 'Sitemap controller', null],
         ['presta_sitemap.dump_command', 'Dump sitemap command', 'console.command'],
     ];

--- a/tests/Unit/EventListener/RouteAnnotationEventListenerTest.php
+++ b/tests/Unit/EventListener/RouteAnnotationEventListenerTest.php
@@ -147,7 +147,8 @@ class RouteAnnotationEventListenerTest extends TestCase
             ['resource_type' => 'closure']
         );
 
-        $dispatcher->addSubscriber(new RouteAnnotationEventListener($router, $dispatcher, 'default'));
+        $listener = new RouteAnnotationEventListener($router, $dispatcher, 'default');
+        $dispatcher->addListener(SitemapPopulateEvent::class, [$listener, 'registerRouteAnnotation']);
         $dispatcher->dispatch($event, SitemapPopulateEvent::class);
     }
 

--- a/tests/Unit/EventListener/StaticRoutesAlternateEventListenerTest.php
+++ b/tests/Unit/EventListener/StaticRoutesAlternateEventListenerTest.php
@@ -115,8 +115,9 @@ class StaticRoutesAlternateEventListenerTest extends TestCase
 
     private function dispatch(array $listenerOptions, string $route, array $options = []): SitemapAddUrlEvent
     {
+        $listener = new StaticRoutesAlternateEventListener($this->router, $listenerOptions);
         $dispatcher = new EventDispatcher();
-        $dispatcher->addSubscriber(new StaticRoutesAlternateEventListener($this->router, $listenerOptions));
+        $dispatcher->addListener(SitemapAddUrlEvent::class, [$listener, 'addAlternate']);
 
         $event = new SitemapAddUrlEvent($route, $options);
         $dispatcher->dispatch($event, SitemapAddUrlEvent::class);


### PR DESCRIPTION
What I've seen lately in the Symfony ecosystem, seems to push everything in favor of Attributes usage  
I'm not sure we will ever get to the point where event subscribers will be deprecated, but it might be safer to switch while we are bumping a major version

(for instance, event subscribers for Doctrine events were deprecated)