### PR TITLE
Add deprecation when UrlGeneratorInterface is missing in events

### DIFF
--- a/src/Event/SitemapAddUrlEvent.php
+++ b/src/Event/SitemapAddUrlEvent.php
@@ -69,6 +69,12 @@ class SitemapAddUrlEvent extends Event
         $this->route = $route;
         $this->options = $options;
         $this->urlGenerator = $urlGenerator;
+        if ($urlGenerator === null) {
+            @trigger_error(
+                'Not injecting the $urlGenerator in ' . __CLASS__ . ' is deprecated and will be required in 4.0.',
+                \E_USER_DEPRECATED
+            );
+        }
     }
 
     /**

--- a/src/Event/SitemapPopulateEvent.php
+++ b/src/Event/SitemapPopulateEvent.php
@@ -59,6 +59,12 @@ class SitemapPopulateEvent extends Event
         $this->urlContainer = $urlContainer;
         $this->section = $section;
         $this->urlGenerator = $urlGenerator;
+        if ($urlGenerator === null) {
+            @trigger_error(
+                'Not injecting the $urlGenerator in ' . __CLASS__ . ' is deprecated and will be required in 4.0.',
+                \E_USER_DEPRECATED
+            );
+        }
     }
 
     /**

--- a/tests/Unit/EventListener/StaticRoutesAlternateEventListenerTest.php
+++ b/tests/Unit/EventListener/StaticRoutesAlternateEventListenerTest.php
@@ -118,7 +118,7 @@ class StaticRoutesAlternateEventListenerTest extends TestCase
         $dispatcher = new EventDispatcher();
         $dispatcher->addSubscriber(new StaticRoutesAlternateEventListener($this->router, $listenerOptions));
 
-        $event = new SitemapAddUrlEvent($route, $options);
+        $event = new SitemapAddUrlEvent($route, $options, $this->router);
         $dispatcher->dispatch($event, SitemapAddUrlEvent::class);
 
         return $event;


### PR DESCRIPTION
#317 made clear that we are also missing deprecations about missing `UrlGeneratorInterface` in events