### PR TITLE
Fixed access to fragmented Urlset with Generator

### DIFF
--- a/src/Service/Generator.php
+++ b/src/Service/Generator.php
@@ -52,7 +52,8 @@ class Generator extends AbstractGenerator implements GeneratorInterface
             return $this->getRoot();
         }
 
-        $this->populate($name);
+        $baseName = preg_replace('/(.*?)(_\d+)?/', '\1', $name);
+        $this->populate($baseName);
 
         if (array_key_exists($name, $this->urlsets)) {
             return $this->urlsets[$name];


### PR DESCRIPTION
Replaces #265

When used along with the controller, when accessing an Urlset fragment, the sitemap name is `sitemap.default_1.xml` and the section should be `default`

But for the moment, the section is `default_1` which is wrong