### PR TITLE
Revert "Use https for real URLs"

### DIFF
--- a/src/Sitemap/Sitemapindex.php
+++ b/src/Sitemap/Sitemapindex.php
@@ -75,10 +75,10 @@ class Sitemapindex extends XmlConstraint
     protected function getStructureXml(): string
     {
         $struct = '<?xml version="1.0" encoding="UTF-8"?>';
-        $struct .= '<sitemapindex xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"';
-        $struct .= ' xsi:schemaLocation="https://www.sitemaps.org/schemas/sitemap/0.9' .
-                   ' https://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd"';
-        $struct .= ' xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">SITEMAPS</sitemapindex>';
+        $struct .= '<sitemapindex xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"';
+        $struct .= ' xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9' .
+                   ' http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd"';
+        $struct .= ' xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">SITEMAPS</sitemapindex>';
 
         return $struct;
     }

--- a/src/Sitemap/Url/GoogleMultilangUrlDecorator.php
+++ b/src/Sitemap/Url/GoogleMultilangUrlDecorator.php
@@ -25,7 +25,7 @@ class GoogleMultilangUrlDecorator extends UrlDecorator
     /**
      * @var array<string, string>
      */
-    protected $customNamespaces = ['xhtml' => 'https://www.w3.org/1999/xhtml'];
+    protected $customNamespaces = ['xhtml' => 'http://www.w3.org/1999/xhtml'];
 
     /**
      * @var string

--- a/src/Sitemap/Url/GoogleNewsUrlDecorator.php
+++ b/src/Sitemap/Url/GoogleNewsUrlDecorator.php
@@ -32,7 +32,7 @@ class GoogleNewsUrlDecorator extends UrlDecorator
     /**
      * @var array<string, string>
      */
-    protected $customNamespaces = ['news' => 'https://www.google.com/schemas/sitemap-news/0.9'];
+    protected $customNamespaces = ['news' => 'http://www.google.com/schemas/sitemap-news/0.9'];
 
     /**
      * @var string

--- a/src/Sitemap/Url/GoogleVideoUrlDecorator.php
+++ b/src/Sitemap/Url/GoogleVideoUrlDecorator.php
@@ -25,7 +25,7 @@ class GoogleVideoUrlDecorator extends UrlDecorator
     /**
      * @var array<string, string>
      */
-    protected $customNamespaces = ['video' => 'https://www.google.com/schemas/sitemap-video/1.1'];
+    protected $customNamespaces = ['video' => 'http://www.google.com/schemas/sitemap-video/1.1'];
 
     /**
      * @var string

--- a/src/Sitemap/Url/UrlConcrete.php
+++ b/src/Sitemap/Url/UrlConcrete.php
@@ -132,7 +132,7 @@ class UrlConcrete implements Url
             throw new \RuntimeException(
                 sprintf(
                     'The value "%s" is not supported by the option changefreq.' .
-                    ' See https://www.sitemaps.org/protocol.html#xmlTagDefinitions',
+                    ' See http://www.sitemaps.org/protocol.html#xmlTagDefinitions',
                     $changefreq
                 )
             );
@@ -177,7 +177,7 @@ class UrlConcrete implements Url
                 sprintf(
                     'The value "%s" is not supported by the option priority,' .
                     ' it must be a numeric between 0.0 and 1.0.' .
-                    ' See https://www.sitemaps.org/protocol.html#xmlTagDefinitions',
+                    ' See http://www.sitemaps.org/protocol.html#xmlTagDefinitions',
                     $priority
                 )
             );

--- a/src/Sitemap/Urlset.php
+++ b/src/Sitemap/Urlset.php
@@ -125,7 +125,7 @@ class Urlset extends XmlConstraint
     protected function getStructureXml(): string
     {
         $struct = '<?xml version="1.0" encoding="UTF-8"?>';
-        $struct .= '<urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9" NAMESPACES>URLS</urlset>';
+        $struct .= '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" NAMESPACES>URLS</urlset>';
 
         $namespaces = '';
         foreach ($this->customNamespaces as $key => $location) {

--- a/tests/Integration/src/Listener/SitemapListener.php
+++ b/tests/Integration/src/Listener/SitemapListener.php
@@ -33,7 +33,7 @@ final class SitemapListener implements EventSubscriberInterface
         [
             'title' => 'Post with one image',
             'slug' => 'post-with-one-image',
-            'images' => ['https://lorempixel.com/400/200/technics/1'],
+            'images' => ['http://lorempixel.com/400/200/technics/1'],
             'video' => null,
         ],
         [
@@ -45,7 +45,7 @@ final class SitemapListener implements EventSubscriberInterface
         [
             'title' => 'Post with multimedia',
             'slug' => 'post-with-multimedia',
-            'images' => ['https://lorempixel.com/400/200/technics/2', 'https://lorempixel.com/400/200/technics/3'],
+            'images' => ['http://lorempixel.com/400/200/technics/2', 'http://lorempixel.com/400/200/technics/3'],
             'video' => 'https://www.youtube.com/watch?v=JugaMuswrmk',
         ],
     ];

--- a/tests/Integration/tests/BaseSitemapTestCase.php
+++ b/tests/Integration/tests/BaseSitemapTestCase.php
@@ -23,7 +23,7 @@ abstract class BaseSitemapTestCase extends WebTestCase
     protected static function assertIndex(string $xml, bool $gzip = false): void
     {
         $index = simplexml_load_string($xml);
-        $index->registerXPathNamespace('sm', 'https://www.sitemaps.org/schemas/sitemap/0.9');
+        $index->registerXPathNamespace('sm', 'http://www.sitemaps.org/schemas/sitemap/0.9');
 
         self::assertIndexContainsSectionLink($index, 'static', $gzip);
         self::assertIndexContainsSectionLink($index, 'blog', $gzip);
@@ -34,7 +34,7 @@ abstract class BaseSitemapTestCase extends WebTestCase
     protected static function assertStaticSection(string $xml): void
     {
         $static = simplexml_load_string($xml);
-        $static->registerXPathNamespace('sm', 'https://www.sitemaps.org/schemas/sitemap/0.9');
+        $static->registerXPathNamespace('sm', 'http://www.sitemaps.org/schemas/sitemap/0.9');
 
         if (Kernel::VERSION_ID >= 50100) {
             self::assertSectionContainsCountUrls($static, 'static', 4);
@@ -58,9 +58,9 @@ abstract class BaseSitemapTestCase extends WebTestCase
     protected static function assertBlogSection(string $xml): void
     {
         $blog = simplexml_load_string($xml);
-        $blog->registerXPathNamespace('sm', 'https://www.sitemaps.org/schemas/sitemap/0.9');
-        $blog->registerXPathNamespace('image', 'https://www.google.com/schemas/sitemap-image/1.1');
-        $blog->registerXPathNamespace('video', 'https://www.google.com/schemas/sitemap-video/1.1');
+        $blog->registerXPathNamespace('sm', 'http://www.sitemaps.org/schemas/sitemap/0.9');
+        $blog->registerXPathNamespace('image', 'http://www.google.com/schemas/sitemap-image/1.1');
+        $blog->registerXPathNamespace('video', 'http://www.google.com/schemas/sitemap-video/1.1');
 
         self::assertSectionContainsCountUrls($blog, 'blog', 5);
         $list = self::assertSectionContainsPath($blog, 'blog', '/blog');
@@ -68,19 +68,19 @@ abstract class BaseSitemapTestCase extends WebTestCase
         $postWithoutMedia = self::assertSectionContainsPath($blog, 'blog', '/blog/post-without-media');
         self::assertUrlConcrete($postWithoutMedia, 'blog', 0.5, 'daily');
         $postWithOneImage = self::assertSectionContainsPath($blog, 'blog', '/blog/post-with-one-image');
-        self::assertUrlHasImage($postWithOneImage, 'blog', 'https://lorempixel.com/400/200/technics/1');
+        self::assertUrlHasImage($postWithOneImage, 'blog', 'http://lorempixel.com/400/200/technics/1');
         $postWithAVideo = self::assertSectionContainsPath($blog, 'blog', '/blog/post-with-a-video');
         self::assertUrlHasVideo($postWithAVideo, 'blog', 'https://www.youtube.com/watch?v=j6IKRxH8PTg');
         $postWithMultimedia = self::assertSectionContainsPath($blog, 'blog', '/blog/post-with-multimedia');
-        self::assertUrlHasImage($postWithMultimedia, 'blog', 'https://lorempixel.com/400/200/technics/2');
-        self::assertUrlHasImage($postWithMultimedia, 'blog', 'https://lorempixel.com/400/200/technics/3');
+        self::assertUrlHasImage($postWithMultimedia, 'blog', 'http://lorempixel.com/400/200/technics/2');
+        self::assertUrlHasImage($postWithMultimedia, 'blog', 'http://lorempixel.com/400/200/technics/3');
         self::assertUrlHasVideo($postWithMultimedia, 'blog', 'https://www.youtube.com/watch?v=JugaMuswrmk');
     }
 
     protected static function assertArchivesSection(string $xml): void
     {
         $archives = simplexml_load_string($xml);
-        $archives->registerXPathNamespace('sm', 'https://www.sitemaps.org/schemas/sitemap/0.9');
+        $archives->registerXPathNamespace('sm', 'http://www.sitemaps.org/schemas/sitemap/0.9');
 
         self::assertSectionContainsCountUrls($archives, 'archive', 10);
         Assert::assertCount(

--- a/tests/Unit/Service/DumperTest.php
+++ b/tests/Unit/Service/DumperTest.php
@@ -177,9 +177,9 @@ class DumperTest extends TestCase
         yield [
             <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
-<sitemapindex xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
-              xsi:schemaLocation="https://www.sitemaps.org/schemas/sitemap/0.9 https://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd"
-              xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
+<sitemapindex xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd"
+              xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     <sitemap>
         <!-- missing <loc> tag -->
         <lastmod>2020-08-19T20:04:26+02:00</lastmod>
@@ -191,9 +191,9 @@ XML
         yield [
             <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
-<sitemapindex xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
-              xsi:schemaLocation="https://www.sitemaps.org/schemas/sitemap/0.9 https://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd"
-              xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
+<sitemapindex xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd"
+              xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     <sitemap>
         <loc>https://acme.org/sitemap.default.xml.gz</loc>
         <!-- missing <lastmod> tag -->

--- a/tests/Unit/Sitemap/SitemapindexTest.php
+++ b/tests/Unit/Sitemap/SitemapindexTest.php
@@ -49,7 +49,7 @@ class SitemapindexTest extends TestCase
         $sitemapindex = new Sitemap\Sitemapindex();
         $xml = $sitemapindex->toXml();
         self::assertXmlStringEqualsXmlString(
-            '<?xml version="1.0" encoding="UTF-8"?><sitemapindex xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://www.sitemaps.org/schemas/sitemap/0.9 https://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd" xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"></sitemapindex>',
+            '<?xml version="1.0" encoding="UTF-8"?><sitemapindex xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></sitemapindex>',
             $xml
         );
     }

--- a/tests/Unit/Sitemap/Url/GoogleNewsUrlDecoratorTest.php
+++ b/tests/Unit/Sitemap/Url/GoogleNewsUrlDecoratorTest.php
@@ -36,7 +36,7 @@ class GoogleNewsUrlDecoratorTest extends TestCase
         $dom = new \DOMDocument();
         $dom->loadXML($this->generateXml($url));
 
-        $newsTags = $dom->getElementsByTagNameNS('https://www.google.com/schemas/sitemap-news/0.9', '*');
+        $newsTags = $dom->getElementsByTagNameNS('http://www.google.com/schemas/sitemap-news/0.9', '*');
 
         self::assertEquals(6, $newsTags->length, 'Could not find news specific tags');
     }
@@ -54,7 +54,7 @@ class GoogleNewsUrlDecoratorTest extends TestCase
         $dom = new \DOMDocument();
         $dom->loadXML($this->generateXml($url));
 
-        $dateNodes = $dom->getElementsByTagNameNS('https://www.google.com/schemas/sitemap-news/0.9', 'publication_date');
+        $dateNodes = $dom->getElementsByTagNameNS('http://www.google.com/schemas/sitemap-news/0.9', 'publication_date');
         self::assertEquals(1, $dateNodes->length, 'Could not find news:publication_date tag');
         self::assertEquals($date->format(\DateTime::W3C), $dateNodes->item(0)->textContent, 'Date was not formatted properly');
     }
@@ -73,7 +73,7 @@ class GoogleNewsUrlDecoratorTest extends TestCase
         $dom = new \DOMDocument();
         $dom->loadXML($this->generateXml($url));
 
-        $dateNodes = $dom->getElementsByTagNameNS('https://www.google.com/schemas/sitemap-news/0.9', 'publication_date');
+        $dateNodes = $dom->getElementsByTagNameNS('http://www.google.com/schemas/sitemap-news/0.9', 'publication_date');
         self::assertEquals(1, $dateNodes->length, 'Could not find news:publication_date tag');
         self::assertEquals($date->format('Y-m-d'), $dateNodes->item(0)->textContent, 'Date was not formatted properly');
     }
@@ -103,7 +103,7 @@ class GoogleNewsUrlDecoratorTest extends TestCase
 
         $dom = new \DOMDocument();
         $dom->loadXML($this->generateXml($url));
-        $accessNodes = $dom->getElementsByTagNameNS('https://www.google.com/schemas/sitemap-news/0.9', 'access');
+        $accessNodes = $dom->getElementsByTagNameNS('http://www.google.com/schemas/sitemap-news/0.9', 'access');
         self::assertEquals(1, $accessNodes->length, 'Could not find news:access tag');
         self::assertEquals('Registration', $accessNodes->item(0)->textContent, 'Acces tag did not contain the right value');
     }
@@ -134,7 +134,7 @@ class GoogleNewsUrlDecoratorTest extends TestCase
 
         $dom = new \DOMDocument();
         $dom->loadXML($this->generateXml($url));
-        $geoNodes = $dom->getElementsByTagNameNS('https://www.google.com/schemas/sitemap-news/0.9', 'geo_locations');
+        $geoNodes = $dom->getElementsByTagNameNS('http://www.google.com/schemas/sitemap-news/0.9', 'geo_locations');
         self::assertEquals(1, $geoNodes->length, 'Could not find news:geo_locations tag');
         self::assertEquals('Detroit, Michigan, USA', $geoNodes->item(0)->textContent, 'Locations tag did not contain the right value');
     }
@@ -191,7 +191,7 @@ class GoogleNewsUrlDecoratorTest extends TestCase
         );
         $dom = new \DOMDocument();
         $dom->loadXML($this->generateXml($url));
-        $stockNodes = $dom->getElementsByTagNameNS('https://www.google.com/schemas/sitemap-news/0.9', 'stock_tickers');
+        $stockNodes = $dom->getElementsByTagNameNS('http://www.google.com/schemas/sitemap-news/0.9', 'stock_tickers');
         self::assertEquals(1, $stockNodes->length, 'Could not find news:stock_tickers tag');
         self::assertEquals('NYSE:OWW, NASDAQ:GTAT', $stockNodes->item(0)->textContent, 'Stock tickers tag did not contain the right value');
     }

--- a/tests/Unit/Sitemap/Url/GoogleVideoUrlDecoratorTest.php
+++ b/tests/Unit/Sitemap/Url/GoogleVideoUrlDecoratorTest.php
@@ -64,7 +64,7 @@ class GoogleVideoUrlDecoratorTest extends TestCase
 
         $this->xml = new \DOMDocument();
 
-        $xml = '<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"';
+        $xml = '<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"';
 
         foreach ($url->getCustomNamespaces() as $name => $uri) {
             $xml .= ' xmlns:' . $name . '="' . $uri . '"';
@@ -77,7 +77,7 @@ class GoogleVideoUrlDecoratorTest extends TestCase
 
     public function testCountNamespaces(): void
     {
-        $namespaces = $this->xml->getElementsByTagNameNS('https://www.google.com/schemas/sitemap-video/1.1', '*');
+        $namespaces = $this->xml->getElementsByTagNameNS('http://www.google.com/schemas/sitemap-video/1.1', '*');
         self::assertEquals(72, $namespaces->length);
     }
 
@@ -117,8 +117,8 @@ class GoogleVideoUrlDecoratorTest extends TestCase
     public function testTagsByVideo(): void
     {
         $xpath = new \DOMXPath($this->xml);
-        $xpath->registerNamespace('s', 'https://www.sitemaps.org/schemas/sitemap/0.9');
-        $xpath->registerNamespace('v', 'https://www.google.com/schemas/sitemap-video/1.1');
+        $xpath->registerNamespace('s', 'http://www.sitemaps.org/schemas/sitemap/0.9');
+        $xpath->registerNamespace('v', 'http://www.google.com/schemas/sitemap-video/1.1');
 
         self::assertEquals('http://acme.com/video/thumbnail1.jpg', $xpath->evaluate('string(/s:urlset/s:url/v:video[1]/v:thumbnail_loc)'));
         self::assertEquals('http://acme.com/video/thumbnail2.jpg', $xpath->evaluate('string(/s:urlset/s:url/v:video[2]/v:thumbnail_loc)'));

--- a/tests/Unit/Sitemap/Url/UrlConcreteTest.php
+++ b/tests/Unit/Sitemap/Url/UrlConcreteTest.php
@@ -139,7 +139,7 @@ class UrlConcreteTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage(
             "The value \"$value\" is not supported by the option priority, it must be a numeric between 0.0 and 1.0." .
-            " See https://www.sitemaps.org/protocol.html#xmlTagDefinitions"
+            " See http://www.sitemaps.org/protocol.html#xmlTagDefinitions"
         );
 
         $url = new UrlConcrete('http://example.com');


### PR DESCRIPTION
Reverts prestaconcept/PrestaSitemapBundle#337

As reported in #340, since we merged this PR, we are producing invalid sitemaps.
It seems to be because the XML namespaces of sitemaps are declared with http instead of https.