### PR TITLE
Fix DI Extension class deprecation with Symfony 7.1

### DIFF
--- a/src/DependencyInjection/PrestaSitemapExtension.php
+++ b/src/DependencyInjection/PrestaSitemapExtension.php
@@ -11,12 +11,10 @@
 
 namespace Presta\SitemapBundle\DependencyInjection;
 
-use Presta\SitemapBundle\Event\SitemapAddUrlEvent;
-use Presta\SitemapBundle\Event\SitemapPopulateEvent;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 /**


### PR DESCRIPTION
The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered internal since Symfony 7.1, to be deprecated in 8.1; use Symfony\Component\DependencyInjection\Extension\Extension instead. It may change without further notice. You should not use it from "Presta\SitemapBundle\DependencyInjection\PrestaSitemapExtension".