### PR TITLE
Fixed potentially undefined uri from stream_get_meta_data

### DIFF
--- a/src/Sitemap/DumpingUrlset.php
+++ b/src/Sitemap/DumpingUrlset.php
@@ -58,8 +58,10 @@ class DumpingUrlset extends Urlset
 
         $streamInfo = stream_get_meta_data($this->bodyFile);
         fclose($this->bodyFile);
-        // removing temporary file
-        unlink($streamInfo['uri']);
+        if (isset($streamInfo['uri'])) {
+            // removing temporary file
+            unlink($streamInfo['uri']);
+        }
 
         if ($gzip) {
             $this->loc .= '.gz';


### PR DESCRIPTION
```
 ------ ---------------------------------------------------------------------- 
  Line   Sitemap/DumpingUrlset.php                                             
 ------ ---------------------------------------------------------------------- 
  62     Offset 'uri' does not exist on array{timed_out: bool, blocked: bool,  
         eof: bool, unread_bytes: int, stream_type: string, wrapper_type:      
         string, wrapper_data: mixed, mode: string, ...}.                      
 ------ ---------------------------------------------------------------------- 
```