### PR TITLE
Fixed stream_get_meta_data uri is always defined

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,6 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Offset 'uri' on array\\{timed_out\\: bool, blocked\\: bool, eof\\: bool, unread_bytes\\: int, stream_type\\: string, wrapper_type\\: string, wrapper_data\\: mixed, mode\\: string, \\.\\.\\.\\} in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: src/Sitemap/DumpingUrlset.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,3 +1,6 @@
+includes:
+  - phpstan-baseline.neon
+
 parameters:
   level: max
   paths:


### PR DESCRIPTION
OK... Now that I fixed PhpStan error in https://github.com/prestaconcept/PrestaSitemapBundle/pull/345

```
 ------ ---------------------------------------------------------------------- 
  Line   Sitemap/DumpingUrlset.php                                             
 ------ ---------------------------------------------------------------------- 
  62     Offset 'uri' does not exist on array{timed_out: bool, blocked: bool,  
         eof: bool, unread_bytes: int, stream_type: string, wrapper_type:      
         string, wrapper_data: mixed, mode: string, ...}.                      
 ------ ---------------------------------------------------------------------- 
```

And now that we are running tests on PHP 8.3, we have the opposite error

```
 ------ ---------------------------------------------------------------------- 
  Line   Sitemap/DumpingUrlset.php                                             
 ------ ---------------------------------------------------------------------- 
  61     Offset 'uri' on array{timed_out: bool, blocked: bool, eof: bool,      
         unread_bytes: int, stream_type: string, wrapper_type: string,         
         wrapper_data: mixed, mode: string, ...} in isset() always exists and  
         is not nullable.                                                      
 ------ ---------------------------------------------------------------------- 
```

I decided to just ignore this error, because this is no big deal, and it really depends on the PHP version, and we are not even close to only support `PHP >= 8.3`