### PR TITLE
URL-encode URLs

### DIFF
--- a/src/Sitemap/Url/GoogleImage.php
+++ b/src/Sitemap/Url/GoogleImage.php
@@ -177,7 +177,7 @@ class GoogleImage
     {
         $xml = '<image:image>';
 
-        $xml .= '<image:loc>' . Utils::encode($this->getLocation()) . '</image:loc>';
+        $xml .= '<image:loc>' . Utils::encodeUrl($this->getLocation()) . '</image:loc>';
 
         if ($this->getCaption()) {
             $xml .= '<image:caption>' . Utils::cdata($this->getCaption()) . '</image:caption>';

--- a/src/Sitemap/Url/GoogleMultilangUrlDecorator.php
+++ b/src/Sitemap/Url/GoogleMultilangUrlDecorator.php
@@ -65,7 +65,7 @@ class GoogleMultilangUrlDecorator extends UrlDecorator
 
         return '<xhtml:link rel="' . $rel
             . '" hreflang="' . $hreflang
-            . '" href="' . Utils::encode($href) . '" />';
+            . '" href="' . Utils::encodeUrl($href) . '" />';
     }
 
     /**

--- a/src/Sitemap/Url/GoogleVideo.php
+++ b/src/Sitemap/Url/GoogleVideo.php
@@ -941,7 +941,7 @@ class GoogleVideo
 
         //----------------------
         // required fields
-        $videoXml .= '<video:thumbnail_loc>' . Utils::encode($this->getThumbnailLocation()) . '</video:thumbnail_loc>';
+        $videoXml .= '<video:thumbnail_loc>' . Utils::encodeUrl($this->getThumbnailLocation()) . '</video:thumbnail_loc>';
         $videoXml .= '<video:title>' . Utils::cdata($this->getTitle()) . '</video:title>';
         $videoXml .= '<video:description>' . Utils::cdata($this->getDescription()) . '</video:description>';
 
@@ -952,7 +952,7 @@ class GoogleVideo
             $videoXml .= '<video:category>' . Utils::cdata($category) . '</video:category>';
         }
         if ($location = $this->getContentLocation()) {
-            $videoXml .= '<video:content_loc>' . Utils::encode($location) . '</video:content_loc>';
+            $videoXml .= '<video:content_loc>' . Utils::encodeUrl($location) . '</video:content_loc>';
         }
         if ($duration = $this->getDuration()) {
             $videoXml .= '<video:duration>' . $duration . '</video:duration>';

--- a/src/Sitemap/Url/UrlConcrete.php
+++ b/src/Sitemap/Url/UrlConcrete.php
@@ -199,7 +199,7 @@ class UrlConcrete implements Url
      */
     public function toXml(): string
     {
-        $xml = '<url><loc>' . Utils::encode($this->getLoc()) . '</loc>';
+        $xml = '<url><loc>' . Utils::encodeUrl($this->getLoc()) . '</loc>';
 
         $lastmod = $this->getLastmod();
         if ($lastmod) {

--- a/src/Sitemap/Utils.php
+++ b/src/Sitemap/Utils.php
@@ -74,7 +74,7 @@ class Utils
             $parts['host'].
             (!empty($parts['port']) ? ':'.$parts['port'] : '').
             (!empty($sanitizedPath) ? $sanitizedPath : '').
-            (!empty($parts['query']) ? '?'.$parts['query'] : '').
+            (!empty($parts['query']) ? '?'.self::encode($parts['query']) : '').
             (!empty($parts['fragment']) ? '#'.$parts['fragment'] : '');
 
         return $targetUrl;

--- a/src/Sitemap/Utils.php
+++ b/src/Sitemap/Utils.php
@@ -39,4 +39,44 @@ class Utils
     {
         return htmlspecialchars($string, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
     }
+
+    /**
+     * Encode URL
+     *
+     * @param string $string
+     *
+     * @return string
+     */
+    public static function encodeUrl(string $url): string
+    {
+        $parts = parse_url($url);
+
+        // Optional but we only sanitize URLs with scheme and host defined
+        if ($parts === false || empty($parts['scheme']) || empty($parts['host'])) {
+            return $url;
+        }
+
+        $sanitizedPath = null;
+        if (!empty($parts['path'])) {
+            $pathParts = explode('/', $parts['path']);
+            foreach ($pathParts as $pathPart) {
+                if (empty($pathPart)) {
+                    continue;
+                }
+                // The Path part might already be urlencoded
+                $sanitizedPath .= '/'.rawurlencode(rawurldecode($pathPart));
+            }
+        }
+
+        // Build the url
+        $targetUrl = $parts['scheme'].'://'.
+            ((!empty($parts['user']) && !empty($parts['pass'])) ? $parts['user'].':'.$parts['pass'].'@' : '').
+            $parts['host'].
+            (!empty($parts['port']) ? ':'.$parts['port'] : '').
+            (!empty($sanitizedPath) ? $sanitizedPath : '').
+            (!empty($parts['query']) ? '?'.$parts['query'] : '').
+            (!empty($parts['fragment']) ? '#'.$parts['fragment'] : '');
+
+        return $targetUrl;
+    }
 }

--- a/tests/Unit/Sitemap/Url/UrlConcreteTest.php
+++ b/tests/Unit/Sitemap/Url/UrlConcreteTest.php
@@ -31,6 +31,8 @@ class UrlConcreteTest extends TestCase
             ['<url><loc>http://example.com/</loc></url>', 'http://example.com/'],
             ['<url><loc>http://example.com/abcd</loc></url>', 'http://example.com/abcd'],
             ['<url><loc>http://example.com/abcd/?a=1&amp;b=cdf</loc></url>', 'http://example.com/abcd/?a=1&b=cdf'],
+            ['<url><loc>http://example.com/%C3%A4</loc></url>', 'http://example.com/ä'],
+            ['<url><loc>http://example.com/folder/%C3%A4</loc></url>', 'http://example.com/folder/ä'],
             [
                 '<url><loc>http://example.com/</loc><lastmod>2012-12-29T10:39:12+00:00</lastmod></url>',
                 'http://example.com/',

--- a/tests/Unit/Sitemap/UtilsTest.php
+++ b/tests/Unit/Sitemap/UtilsTest.php
@@ -27,4 +27,10 @@ class UtilsTest extends TestCase
         $actual = Utils::encode('data & spécial chars>');
         self::assertEquals('data &amp; spécial chars&gt;', $actual);
     }
+
+    public function testEncodeUrl(): void
+    {
+        $actual = Utils::encodeUrl('http://example.org/test_ä');
+        self::assertEquals('http://example.org/test_%C3%A4', $actual);
+    }
 }


### PR DESCRIPTION
Currently there is only one `Utils::encode()` method which gets used to encode URLs as well as textual content.
For example in https://github.com/prestaconcept/PrestaSitemapBundle/blob/62bf18acdf81220bd79c1114166bffa9173f2fff/src/Sitemap/Url/UrlConcrete.php#L202
the `<loc>` gets encoded with 
https://github.com/prestaconcept/PrestaSitemapBundle/blob/62bf18acdf81220bd79c1114166bffa9173f2fff/src/Sitemap/Utils.php#L40

With the following code
```php
$url = new \Presta\SitemapBundle\Sitemap\Url\UrlConcrete('http://example.org/umlaut_url_ä');
var_dump($url->toXml());
```
the generated XML is:
```xml
<url>
  <loc>http://example.org/umlaut_url_ä</loc>
</url>
```

Actually this is not a valid URL according to [RFC3986](https://www.ietf.org/rfc/rfc3986.txt) (also see https://stackoverflow.com/questions/1856785/characters-allowed-in-a-url for summary). Although such URLs work when being called in a browser because the browser URL-encodes it, this library should follow the RFC imho.

With this PR above code would generate this XML:
```xml
<url>
  <loc>http://example.org/umlaut_url_%C3%A4</loc>
</url>
```
This is exactly the same as when you call http://example.org/umlaut_url_ä in your browser and then copy-paste the URL to a text editor.