### PR TITLE
Move setting of parameters before loading services

### DIFF
--- a/src/DependencyInjection/PrestaSitemapExtension.php
+++ b/src/DependencyInjection/PrestaSitemapExtension.php
@@ -30,15 +30,15 @@ class PrestaSitemapExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../../config'));
-        $loader->load('services.xml');
-
         $container->setParameter($this->getAlias() . '.dump_directory', (string)$config['dump_directory']);
         $container->setParameter($this->getAlias() . '.timetolive', (int)$config['timetolive']);
         $container->setParameter($this->getAlias() . '.sitemap_file_prefix', (string)$config['sitemap_file_prefix']);
         $container->setParameter($this->getAlias() . '.items_by_set', (int)$config['items_by_set']);
         $container->setParameter($this->getAlias() . '.defaults', $config['defaults']);
         $container->setParameter($this->getAlias() . '.default_section', (string)$config['default_section']);
+
+        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../../config'));
+        $loader->load('services.xml');
 
         if (true === $config['route_annotation_listener']) {
             $loader->load('route_annotation_listener.xml');

--- a/tests/Integration/tests/BaseSitemapTestCase.php
+++ b/tests/Integration/tests/BaseSitemapTestCase.php
@@ -14,9 +14,7 @@ namespace Presta\SitemapBundle\Tests\Integration\Tests;
 use PHPUnit\Framework\Assert;
 use Presta\SitemapBundle\Tests\Integration\Kernel;
 use SimpleXMLElement;
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 abstract class BaseSitemapTestCase extends WebTestCase
 {


### PR DESCRIPTION
This change fixes the following issue: When you configure a custom `dump_directory`, the setting is not passed to services. The extension loads the services before setting the parameters resulting in the default for `dump_directory`.

Todo:
- [ ] add tests covering the behaviour

Bonus: Remove unused imports from testfile.