### PR TITLE
Reset generator state after fetch to prevent URL accumulation in persistent runtimes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.idea/
 /.phpcs-cache
+/.phpunit.cache
 /.phpunit.result.cache
 /composer.lock
 /vendor/

--- a/config/services.php
+++ b/config/services.php
@@ -21,7 +21,8 @@ return static function (ContainerConfigurator $container) {
             service('router'),
             '%presta_sitemap.items_by_set%',
         ])
-        ->call('setDefaults', ['%presta_sitemap.defaults%']);
+        ->call('setDefaults', ['%presta_sitemap.defaults%'])
+        ->tag('kernel.reset', ['method' => 'reset']);
 
     $services->set('presta_sitemap.dumper_default', '%presta_sitemap.dumper.class%')
         ->args([

--- a/src/Service/Generator.php
+++ b/src/Service/Generator.php
@@ -46,20 +46,25 @@ class Generator extends AbstractGenerator implements GeneratorInterface
      */
     public function fetch(string $name): ?XmlConstraint
     {
-        if ('root' === $name) {
-            $this->populate();
+        try {
+            if ('root' === $name) {
+                $this->populate();
 
-            return $this->getRoot();
+                return $this->getRoot();
+            }
+
+            $baseName = preg_replace('/(.*?)(_\d+)?/', '\1', $name);
+            $this->populate($baseName);
+
+            if (array_key_exists($name, $this->urlsets)) {
+                return $this->urlsets[$name];
+            }
+
+            return null;
+        } finally {
+            $this->root = null;
+            $this->urlsets = [];
         }
-
-        $baseName = preg_replace('/(.*?)(_\d+)?/', '\1', $name);
-        $this->populate($baseName);
-
-        if (array_key_exists($name, $this->urlsets)) {
-            return $this->urlsets[$name];
-        }
-
-        return null;
     }
 
     /**

--- a/src/Service/Generator.php
+++ b/src/Service/Generator.php
@@ -15,11 +15,12 @@ use Presta\SitemapBundle\Sitemap\Urlset;
 use Presta\SitemapBundle\Sitemap\XmlConstraint;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * Sitemap generator.
  */
-class Generator extends AbstractGenerator implements GeneratorInterface
+class Generator extends AbstractGenerator implements GeneratorInterface, ResetInterface
 {
     /**
      * @var UrlGeneratorInterface
@@ -62,9 +63,17 @@ class Generator extends AbstractGenerator implements GeneratorInterface
 
             return null;
         } finally {
-            $this->root = null;
-            $this->urlsets = [];
+            $this->reset();
         }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function reset(): void
+    {
+        $this->root = null;
+        $this->urlsets = [];
     }
 
     /**

--- a/tests/Unit/Service/GeneratorTest.php
+++ b/tests/Unit/Service/GeneratorTest.php
@@ -75,6 +75,27 @@ class GeneratorTest extends WebTestCase
         self::assertTrue($triggered, 'Event listener was triggered');
     }
 
+    public function testFetchDoesNotAccumulateAcrossCalls(): void
+    {
+        $this->eventDispatcher->addListener(SitemapPopulateEvent::class, function (SitemapPopulateEvent $event): void {
+            $event->getUrlContainer()->addUrl(new UrlConcrete('http://acme.com/page-1'), 'default');
+        });
+
+        // Reuse the same generator instance to emulate a persistent runtime
+        // (e.g. FrankenPHP worker mode) where the shared service survives
+        // across requests. A high items-by-set limit ensures the URLs would
+        // pile up in the same urlset rather than overflow to a new one.
+        $generator = new Generator($this->eventDispatcher, $this->router, 100);
+
+        $first = $generator->fetch('default');
+        self::assertInstanceOf(Urlset::class, $first);
+        self::assertCount(1, $first);
+
+        $second = $generator->fetch('default');
+        self::assertInstanceOf(Urlset::class, $second);
+        self::assertCount(1, $second, 'URLs must not pile up when fetch() is called again');
+    }
+
     public function testRouterInjectedIntoEvent(): void
     {
         $eventRouter = null;

--- a/tests/Unit/Service/GeneratorTest.php
+++ b/tests/Unit/Service/GeneratorTest.php
@@ -96,6 +96,19 @@ class GeneratorTest extends WebTestCase
         self::assertCount(1, $second, 'URLs must not pile up when fetch() is called again');
     }
 
+    public function testResetClearsAccumulatedState(): void
+    {
+        $generator = new Generator($this->eventDispatcher, $this->router, 100);
+
+        // Populate the urlset without going through fetch() (which resets on its own).
+        $generator->addUrl(new UrlConcrete('http://acme.com/manual'), 'default');
+        self::assertCount(1, $generator->getUrlset('default'));
+
+        $generator->reset();
+
+        self::assertCount(0, $generator->getUrlset('default'), 'reset() must clear the accumulated urlsets');
+    }
+
     public function testRouterInjectedIntoEvent(): void
     {
         $eventRouter = null;


### PR DESCRIPTION
Fixes #362

## Problem

`Generator` is registered as a **shared** service and is **stateful**: `fetch()` calls `populate()`, which dispatches `SitemapPopulateEvent`, and listeners append their URLs into `AbstractGenerator::$urlsets`. However, `fetch()` never resets `$urlsets` / `$root` before returning.

Under classic PHP-FPM this is harmless because the container is rebuilt on every request. But in a **persistent runtime** (FrankenPHP worker mode, RoadRunner, Swoole) the kernel and its shared services survive across requests, so previously-collected URLs remain in `$urlsets` and listeners append the same URLs again — each `<loc>` ends up duplicated once per request handled by the same worker process.

Note this only affects the **live** controller path; the `Dumper` path is fine because `Dumper::dump()` already resets state via `cleanup()` in a `finally` block.

## Fix

Reset `$root` / `$urlsets` in a `finally` block once the section has been built, mirroring `Dumper::dump()`.

Resetting at the **end** of `fetch()` (rather than the start, as suggested in the issue) is deliberate: it preserves the public `addUrl()`-then-`fetch()` pattern within a single request — resetting at the start would discard URLs added manually before `fetch()` (a regression caught by `GoogleNewsUrlDecoratorTest`). The returned `Urlset` / `Sitemapindex` object is already built and held by the caller before the array is cleared, so returning it after cleanup is safe. The controller only performs a single `fetch()` per request.

## Test

Added `testFetchDoesNotAccumulateAcrossCalls`, which reuses one `Generator` instance across two `fetch()` calls (emulating a persistent worker) and asserts the URL count stays constant. Verified it fails without the fix and passes with it.